### PR TITLE
Add optional Ceres minimizer plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(Eigen3 REQUIRED)
 find_package(Vdt)
 find_package(LCG QUIET) # only used for FindBoost in StatAnalysis
 find_package(Boost CONFIG REQUIRED COMPONENTS program_options filesystem)
+find_package(Ceres)
 
 message(STATUS "Using ROOT From: ${ROOT_INCLUDE_DIRS}")
 include(${ROOT_USE_FILE})
@@ -52,6 +53,16 @@ endif()
 
 add_executable(combine bin/combine.cpp)
 target_link_libraries(combine PUBLIC ${LIBNAME})
+
+if(Ceres_FOUND)
+  message(STATUS "Found Ceres - building CeresMinimizer plugin")
+  add_library(CeresMinimizer SHARED ceres/CeresMinimizer.cc)
+  target_link_libraries(CeresMinimizer PUBLIC ${ROOT_LIBRARIES} Ceres::ceres)
+  target_include_directories(CeresMinimizer PUBLIC ${Ceres_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+  install(TARGETS CeresMinimizer LIBRARY DESTINATION lib)
+else()
+  message(STATUS "Ceres not found - CeresMinimizer plugin will be unavailable")
+endif()
 
 if(MODIFY_ROOTMAP)
         # edit the generated rootmap in-situ before installation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ http://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/latest
 
 The source code of this documentation can be found in the `docs/` folder in this repository.
 
+### Ceres minimizer plugin
+
+When the [Ceres Solver](http://ceres-solver.org) development package is available, the build system produces a `libCeresMinimizer` plugin that exposes Ceres as a `ROOT::Math::Minimizer`. The plugin can be enabled at runtime by selecting it as the default minimizer. Ceres supports both `TrustRegion` (default) and `LineSearch` algorithms:
+
+```
+combine datacard.root --cminDefaultMinimizerType=Ceres --cminDefaultMinimizerAlgo=TrustRegion
+```
+
+Linking against Ceres requires the solver to be discoverable by CMake at build time.
+
 ### Publication 
 
 The `Combine` tool publication can be found [here](https://arxiv.org/abs/2404.06614). Please consider citing this reference if you use the `Combine` tool. 

--- a/ceres/CeresMinimizer.cc
+++ b/ceres/CeresMinimizer.cc
@@ -1,0 +1,337 @@
+#include "../interface/CeresMinimizer.h"
+#include "../interface/CombineLogger.h"
+#include <Math/IMultiGenFunction.h>
+#include <Math/MinimizerOptions.h>
+#include <TPluginManager.h>
+#include <ceres/numeric_diff_cost_function.h>
+#include <ceres/loss_function.h>
+#include <ceres/covariance.h>
+#include <TString.h>
+#include <fstream>
+#include <cstdlib>
+#include <random>
+#include <cmath>
+#include <limits>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+#include <iostream>
+
+CeresMinimizer::CeresMinimizer(const char *) : func_(nullptr), gradFunc_(nullptr), nDim_(0), nFree_(0), nCalls_(0), fMinVal_(0.0), edm_(0.0), numDiffStep_(1e-4), forceNumeric_(false) {}
+
+CeresMinimizer::~CeresMinimizer() {}
+
+void CeresMinimizer::Clear() {
+    func_ = nullptr;
+    gradFunc_ = nullptr;
+    nDim_ = nFree_ = 0;
+    nCalls_ = 0;
+    x_.clear(); step_.clear(); lower_.clear(); upper_.clear(); isFixed_.clear();
+    grad_.clear(); hess_.clear();
+    fMinVal_ = 0.0; edm_ = 0.0;
+    numDiffStep_ = 1e-4;
+    forceNumeric_ = false;
+}
+
+void CeresMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction &func) {
+    func_ = &func;
+    gradFunc_ = dynamic_cast<const ROOT::Math::IMultiGradFunction*>(func_);
+    nDim_ = func.NDim();
+    nFree_ = nDim_;
+    x_.assign(nDim_,0.0);
+    step_.assign(nDim_,0.1);
+    lower_.assign(nDim_,-std::numeric_limits<double>::infinity());
+    upper_.assign(nDim_, std::numeric_limits<double>::infinity());
+    isFixed_.assign(nDim_,false);
+}
+
+bool CeresMinimizer::SetVariable(unsigned int i, const std::string &, double val, double step) {
+    if (i>=nDim_) return false;
+    x_[i] = val; step_[i] = step; isFixed_[i]=false; return true;
+}
+
+bool CeresMinimizer::SetLimitedVariable(unsigned int i, const std::string &, double val, double step, double lower, double upper) {
+    if (i>=nDim_) return false;
+    x_[i]=val; step_[i]=step; lower_[i]=lower; upper_[i]=upper; isFixed_[i]=false; return true;
+}
+
+bool CeresMinimizer::SetFixedVariable(unsigned int i, const std::string &, double val) {
+    if (i>=nDim_) return false;
+    x_[i]=val; isFixed_[i]=true; nFree_--; return true;
+}
+
+CeresMinimizer::CostFunction::CostFunction(const ROOT::Math::IMultiGradFunction *f) : func(f) {
+    set_num_residuals(1);
+    mutable_parameter_block_sizes()->push_back(f->NDim());
+}
+
+bool CeresMinimizer::CostFunction::Evaluate(double const* const* parameters, double *residuals, double **jacobians) const {
+    const double *x = parameters[0];
+    double fval = (*func)(x);
+    residuals[0] = std::sqrt(fval);
+    if (jacobians && jacobians[0]) {
+        std::vector<double> grad(func->NDim());
+        func->Gradient(x, &grad[0]);
+        double coeff = 0.5 / residuals[0];
+        for (unsigned int i=0;i<func->NDim();++i) jacobians[0][i] = coeff * grad[i];
+    }
+    return true;
+}
+
+struct NoGradFunctor {
+    explicit NoGradFunctor(const ROOT::Math::IMultiGenFunction *f) : func(f) {}
+    bool operator()(const double * const x, double *residuals) const {
+        residuals[0] = std::sqrt((*func)(x));
+        return true;
+    }
+    const ROOT::Math::IMultiGenFunction *func;
+};
+
+bool CeresMinimizer::Minimize() {
+    if (!func_) return false;
+
+    // retrieve solver configuration from environment
+    int maxIter = 1000;
+    if (const char *env = std::getenv("CERES_MAX_ITERATIONS")) maxIter = std::atoi(env);
+    std::string linearSolver = std::getenv("CERES_LINEAR_SOLVER") ? std::getenv("CERES_LINEAR_SOLVER") : std::string("dense_qr");
+    unsigned int multiStart = 1;
+    if (const char *env = std::getenv("CERES_MULTI_START")) multiStart = std::max(1, std::atoi(env));
+    double jitter = 1.0;
+    if (const char *env = std::getenv("CERES_JITTER")) jitter = std::max(0.0, std::atof(env));
+    std::string jitterDist = std::getenv("CERES_JITTER_DIST") ? std::getenv("CERES_JITTER_DIST") : std::string("uniform");
+    bool verbose = std::getenv("CERES_VERBOSE") != nullptr;
+    bool progress = std::getenv("CERES_PROGRESS") != nullptr;
+    int numThreads = 1;
+    if (const char *env = std::getenv("CERES_NUM_THREADS")) numThreads = std::max(1, std::atoi(env));
+    else if (std::getenv("CERES_AUTO_THREADS")) {
+        unsigned hw = std::thread::hardware_concurrency();
+        numThreads = hw ? static_cast<int>(hw) : 1;
+    }
+    unsigned int seed = 12345;
+    if (const char *env = std::getenv("CERES_RANDOM_SEED")) seed = static_cast<unsigned int>(std::strtoul(env, nullptr, 10));
+    bool forceNumeric = std::getenv("CERES_FORCE_NUMERIC") != nullptr;
+    forceNumeric_ = forceNumeric;
+
+    double funTol = ROOT::Math::MinimizerOptions::DefaultTolerance();
+    if (const char *env = std::getenv("CERES_FUNCTION_TOLERANCE")) funTol = std::atof(env);
+    double gradTol = funTol;
+    if (const char *env = std::getenv("CERES_GRADIENT_TOLERANCE")) gradTol = std::atof(env);
+    double parTol = funTol;
+    if (const char *env = std::getenv("CERES_PARAMETER_TOLERANCE")) parTol = std::atof(env);
+    std::string algo = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
+    if (const char *env = std::getenv("CERES_ALGO")) algo = env;
+    double numericStep = 1e-4;
+    if (const char *env = std::getenv("CERES_NUMERIC_DIFF_STEP")) numericStep = std::abs(std::atof(env));
+    if (numericStep <= 0) numericStep = 1e-4;
+    numDiffStep_ = numericStep;
+    std::string diffMethod = std::getenv("CERES_DIFF_METHOD") ? std::getenv("CERES_DIFF_METHOD") : std::string("central");
+    std::string lossStr = std::getenv("CERES_LOSS_FUNCTION") ? std::getenv("CERES_LOSS_FUNCTION") : std::string("none");
+    double initRadius = 1.0;
+    if (const char *env = std::getenv("CERES_INITIAL_RADIUS")) initRadius = std::max(1e-12, std::atof(env));
+    double lossScale = 1.0;
+    if (const char *env = std::getenv("CERES_LOSS_SCALE")) lossScale = std::max(0.0, std::atof(env));
+    std::string logFile = std::getenv("CERES_LOG_FILE") ? std::getenv("CERES_LOG_FILE") : std::string();
+    double maxTime = 0.0;
+    if (const char *env = std::getenv("CERES_MAX_TIME")) maxTime = std::max(0.0, std::atof(env));
+    double boundRelax = 0.0;
+    if (const char *env = std::getenv("CERES_BOUND_RELAX")) boundRelax = std::max(0.0, std::atof(env));
+
+    std::vector<double> xbest = x_, xinit = x_;
+    double bestFval = std::numeric_limits<double>::infinity();
+    ceres::Solver::Summary bestSummary;
+
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<double> dist(-1.0,1.0);
+    std::normal_distribution<double> gdist(0.0,1.0);
+    bool useGauss = (jitterDist == "gaussian");
+    auto startTime = std::chrono::steady_clock::now();
+
+    std::string cfgMsg = Form("config algo=%s linearSolver=%s maxIter=%d funTol=%g gradTol=%g parTol=%g threads=%d",
+                              algo.c_str(), linearSolver.c_str(), maxIter, funTol, gradTol, parTol, numThreads);
+    CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, cfgMsg, __func__);
+    if (verbose) std::cout << "Ceres " << cfgMsg << std::endl;
+
+    unsigned int it = 0;
+    for (; it < multiStart; ++it) {
+        if (maxTime > 0.0) {
+            double elapsed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now()-startTime).count();
+            if (elapsed >= maxTime) break;
+        }
+        if (it > 0) {
+            for (unsigned int i = 0; i < nDim_; ++i) {
+                double r = useGauss ? gdist(rng) : dist(rng);
+                x_[i] = xinit[i] + r * step_[i] * jitter;
+            }
+        } else {
+            x_ = xinit;
+        }
+
+        ceres::Problem problem;
+        ceres::CostFunction *cost = nullptr;
+        if (gradFunc_ && !forceNumeric) cost = new CostFunction(gradFunc_);
+        else {
+            ceres::NumericDiffOptions ndOpts; ndOpts.relative_step_size = numericStep;
+            if (diffMethod == "forward")
+                cost = new ceres::NumericDiffCostFunction<NoGradFunctor, ceres::FORWARD, 1, ceres::DYNAMIC>(new NoGradFunctor(func_), ceres::TAKE_OWNERSHIP, nDim_, ndOpts);
+            else
+                cost = new ceres::NumericDiffCostFunction<NoGradFunctor, ceres::CENTRAL, 1, ceres::DYNAMIC>(new NoGradFunctor(func_), ceres::TAKE_OWNERSHIP, nDim_, ndOpts);
+        }
+        ceres::LossFunction *loss = nullptr;
+        if (lossStr == "huber") loss = new ceres::HuberLoss(lossScale);
+        else if (lossStr == "cauchy") loss = new ceres::CauchyLoss(lossScale);
+        problem.AddResidualBlock(cost, loss, x_.data());
+        for (unsigned int i=0;i<nDim_;++i) {
+            if (isFixed_[i]) problem.SetParameterBlockConstant(&x_[i]);
+            else {
+                if (std::isfinite(lower_[i])) problem.SetParameterLowerBound(x_.data(), i, lower_[i]-boundRelax);
+                if (std::isfinite(upper_[i])) problem.SetParameterUpperBound(x_.data(), i, upper_[i]+boundRelax);
+            }
+        }
+        ceres::Solver::Options options;
+        options.max_num_iterations = maxIter;
+        options.function_tolerance = funTol;
+        options.gradient_tolerance = gradTol;
+        options.parameter_tolerance = parTol;
+        options.minimizer_type = (algo == "LineSearch" ? ceres::LINE_SEARCH : ceres::TRUST_REGION);
+        if (linearSolver == "dense_qr") options.linear_solver_type = ceres::DENSE_QR;
+        else if (linearSolver == "dense_normal_cholesky") options.linear_solver_type = ceres::DENSE_NORMAL_CHOLESKY;
+        else if (linearSolver == "iterative_schur") options.linear_solver_type = ceres::ITERATIVE_SCHUR;
+        else if (linearSolver == "sparse_normal_cholesky") options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+        else if (linearSolver == "dense_schur") options.linear_solver_type = ceres::DENSE_SCHUR;
+        else if (linearSolver == "sparse_schur") options.linear_solver_type = ceres::SPARSE_SCHUR;
+        else {
+            CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, Form("Unknown linear solver %s, using dense_qr", linearSolver.c_str()), __func__);
+            options.linear_solver_type = ceres::DENSE_QR;
+        }
+        options.num_threads = numThreads;
+        options.initial_trust_region_radius = initRadius;
+        options.minimizer_progress_to_stdout = progress;
+        ceres::Solver::Summary summary;
+        ceres::Solve(options, &problem, &summary);
+        double fval = (*func_)(x_.data());
+        if (verbose) CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, Form("multi-start %u fval %.6f", it, fval), __func__);
+        if (summary.IsSolutionUsable() && fval < bestFval) {
+            bestFval = fval;
+            xbest = x_;
+            bestSummary = summary;
+        }
+    }
+    if (maxTime > 0.0) {
+        double elapsed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now()-startTime).count();
+        if (elapsed >= maxTime)
+            CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, "time limit reached before completing all starts", __func__);
+    }
+
+    x_ = xbest;
+    nCalls_ = bestSummary.num_successful_steps + bestSummary.num_unsuccessful_steps;
+    fMinVal_ = bestFval;
+    grad_.assign(nDim_,0.0);
+    hess_.assign(nDim_*nDim_,0.0);
+    cov_.assign(nDim_*nDim_,0.0);
+    err_.assign(nDim_,0.0);
+    if (gradFunc_) {
+        gradFunc_->Gradient(x_.data(), &grad_[0]);
+        gradFunc_->Hessian(x_.data(), &hess_[0]);
+    } else {
+        std::vector<double> xtmp = x_;
+        for (unsigned int i=0;i<nDim_;++i) {
+            xtmp[i] += numDiffStep_;
+            double fp = (*func_)(xtmp.data());
+            xtmp[i] -= 2*numDiffStep_;
+            double fm = (*func_)(xtmp.data());
+            grad_[i] = (fp - fm) / (2*numDiffStep_);
+            double f0 = bestFval;
+            hess_[i*nDim_+i] = (fp - 2*f0 + fm)/(numDiffStep_*numDiffStep_);
+            xtmp[i] = x_[i];
+        }
+    }
+
+    // compute covariance and parameter errors
+    {
+        ceres::Problem covProblem;
+        ceres::CostFunction *cost = nullptr;
+        if (gradFunc_ && !forceNumeric_) cost = new CostFunction(gradFunc_);
+        else {
+            ceres::NumericDiffOptions ndOpts; ndOpts.relative_step_size = numDiffStep_;
+            if (diffMethod == "forward")
+                cost = new ceres::NumericDiffCostFunction<NoGradFunctor, ceres::FORWARD, 1, ceres::DYNAMIC>(new NoGradFunctor(func_), ceres::TAKE_OWNERSHIP, nDim_, ndOpts);
+            else
+                cost = new ceres::NumericDiffCostFunction<NoGradFunctor, ceres::CENTRAL, 1, ceres::DYNAMIC>(new NoGradFunctor(func_), ceres::TAKE_OWNERSHIP, nDim_, ndOpts);
+        }
+        ceres::LossFunction *loss = nullptr;
+        if (lossStr == "huber") loss = new ceres::HuberLoss(lossScale);
+        else if (lossStr == "cauchy") loss = new ceres::CauchyLoss(lossScale);
+        covProblem.AddResidualBlock(cost, loss, x_.data());
+        for (unsigned int i=0;i<nDim_;++i) {
+            if (isFixed_[i]) covProblem.SetParameterBlockConstant(&x_[i]);
+            else {
+                if (std::isfinite(lower_[i])) covProblem.SetParameterLowerBound(x_.data(), i, lower_[i]-boundRelax);
+                if (std::isfinite(upper_[i])) covProblem.SetParameterUpperBound(x_.data(), i, upper_[i]+boundRelax);
+            }
+        }
+        ceres::Covariance::Options covOpts;
+        ceres::Covariance covariance(covOpts);
+        std::vector<std::pair<const double*, const double*> > blocks;
+        blocks.emplace_back(x_.data(), x_.data());
+        if (covariance.Compute(blocks, &covProblem)) {
+            covariance.GetCovarianceBlock(x_.data(), x_.data(), &cov_[0]);
+            for (unsigned int i=0;i<nDim_; ++i) err_[i] = std::sqrt(std::fabs(cov_[i*nDim_+i]));
+        }
+    }
+
+    CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, bestSummary.BriefReport(), __func__);
+    if (verbose) CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, bestSummary.FullReport(), __func__);
+    if (!logFile.empty()) {
+        std::ofstream ofs(logFile.c_str(), std::ios::app);
+        if (ofs) ofs << bestSummary.FullReport() << std::endl;
+    }
+
+    if (multiStart > 1 && jitter == 0.0)
+        CombineLogger::instance().log("CeresMinimizer.cc", __LINE__, "multi-start requested without jitter; results may be identical", __func__);
+
+    return bestSummary.IsSolutionUsable();
+}
+
+void CeresMinimizer::Gradient(const double *x, double *grad) const {
+    if (gradFunc_ && !forceNumeric_) {
+        gradFunc_->Gradient(x, grad);
+    } else {
+        std::vector<double> xtmp(nDim_);
+        std::copy(x, x + nDim_, xtmp.begin());
+        for (unsigned int i=0;i<nDim_;++i) {
+            xtmp[i] += numDiffStep_;
+            double fp = (*func_)(xtmp.data());
+            xtmp[i] -= 2*numDiffStep_;
+            double fm = (*func_)(xtmp.data());
+            grad[i] = (fp - fm)/(2*numDiffStep_);
+            xtmp[i] = x[i];
+        }
+    }
+}
+
+void CeresMinimizer::Hessian(const double *x, double *hes) const {
+    if (gradFunc_ && !forceNumeric_) {
+        gradFunc_->Hessian(x, hes);
+    } else {
+        std::vector<double> xtmp(nDim_);
+        std::copy(x, x + nDim_, xtmp.begin());
+        std::vector<double> grad1(nDim_), grad2(nDim_);
+        Gradient(x, &grad1[0]);
+        for (unsigned int j=0;j<nDim_;++j) {
+            xtmp[j] += numDiffStep_;
+            Gradient(xtmp.data(), &grad2[0]);
+            for (unsigned int i=0;i<nDim_;++i) {
+                hes[i*nDim_+j] = (grad2[i]-grad1[i])/numDiffStep_;
+            }
+            xtmp[j] = x[j];
+        }
+    }
+}
+
+namespace {
+    struct CeresMinimizerRegister {
+        CeresMinimizerRegister() {
+            gPluginMgr->AddHandler("ROOT::Math::Minimizer","Ceres","CeresMinimizer","CeresMinimizer","CeresMinimizer()");
+        }
+    } gCeresMinimizerRegister;
+}

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -12,3 +12,4 @@ dependencies:
   - boost-cpp
   - pcre
   - eigen
+  - ceres-solver

--- a/conda_env_exact.yml
+++ b/conda_env_exact.yml
@@ -35,6 +35,7 @@ dependencies:
   - decorator=4.4.2=py_0
   - defusedxml=0.7.1=pyhd3eb1b0_0
   - eigen=3.3.9=h4bd325d_1
+  - ceres-solver
   - entrypoints=0.3=py27h8c360ce_1001
   - enum34=1.1.10=py27h8c360ce_1
   - expat=2.3.0=h9c3ff4c_0

--- a/docs/part3/runningthetool.md
+++ b/docs/part3/runningthetool.md
@@ -87,7 +87,7 @@ All of the fits that are performed in <span style="font-variant:small-caps;">Com
      * `--cminApproxPreFitTolerance arg`: If non-zero, first do a pre-fit with this tolerance (or 10 times the final tolerance, whichever is largest)
      * `--cminApproxPreFitStrategy arg`:   Strategy to use in the pre-fit. The default is strategy 0.
 * `--cminDefaultMinimizerType arg`: Set the default minimizer type. By default this is set to Minuit2.
-* `--cminDefaultMinimizerAlgo arg`: Set the default minimizer algorithm. The default algorithm is Migrad.
+* `--cminDefaultMinimizerAlgo arg`: Set the default minimizer algorithm. The default algorithm is Migrad. When using the optional Ceres plugin the supported algorithms are `TrustRegion` and `LineSearch` (default `TrustRegion`).
 * `--cminDefaultMinimizerTolerance arg`: Set the default minimizer tolerance, the default is 0.1.
 * `--cminDefaultMinimizerStrategy arg`: Set the default minimizer strategy between 0 (speed), 1 (balance - *default*), 2 (robustness). The [Minuit documentation](http://www.fresco.org.uk/minuit/cern/node6.html) for this is pretty sparse but in general, 0 means evaluate the function less often, while 2 will waste function calls to get precise answers. An important note is that the `Hesse` algorithm (for error and correlation estimation) will be run *only* if the strategy is 1 or 2.
 * `--cminFallbackAlgo arg`: Provides a list of fallback algorithms, to be used in case the default minimizer fails. You can provide multiple options using the syntax `Type[,algo],strategy[:tolerance]`: eg `--cminFallbackAlgo Minuit2,Simplex,0:0.1` will fall back to the simplex algorithm of Minuit2 with strategy 0 and a tolerance 0.1, while `--cminFallbackAlgo Minuit2,1` will use the default algorithm (Migrad) of Minuit2 with strategy 1.
@@ -100,6 +100,7 @@ The allowed combinations of minimizer types and minimizer algorithms are as foll
 |`Minuit`	      | `Migrad`, `Simplex`, `Combined`, `Scan` |
 |`Minuit2` 	      | `Migrad`, `Simplex`, `Combined`, `Scan` |
 |`GSLMultiMin`       | `ConjugateFR`, `ConjugatePR`, `BFGS`, `BFGS2`, `SteepestDescent`|
+|`Ceres`             | `TrustRegion`, `LineSearch`|
 
 You can find details about these in the Minuit2 documentation [here](https://root.cern.ch/root/htmldoc/guides/minuit2/Minuit2.html).
 

--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -1,0 +1,80 @@
+#ifndef HiggsAnalysis_CombinedLimit_CeresMinimizer_h
+#define HiggsAnalysis_CombinedLimit_CeresMinimizer_h
+
+#include <Math/Minimizer.h>
+#include <Math/IMultiGradFunction.h>
+#include <ceres/ceres.h>
+#include <string>
+#include <vector>
+#include <memory>
+
+/// Minimizer interface using Ceres Solver
+class CeresMinimizer : public ROOT::Math::Minimizer {
+public:
+    CeresMinimizer(const char *name = nullptr);
+    ~CeresMinimizer() override;
+
+    const char * Name() const override { return "Ceres"; }
+
+    void Clear() override;
+    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
+
+    bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
+    bool SetLimitedVariable(unsigned int ivar, const std::string & name, double val, double step, double lower, double upper) override;
+    bool SetFixedVariable(unsigned int ivar, const std::string & name, double val) override;
+
+    bool Minimize() override;
+
+    double MinValue() const override { return fMinVal_; }
+    double Edm() const override { return edm_; }
+
+    const double * X() const override { return x_.data(); }
+    const double * MinGradient() const override { return grad_.empty() ? nullptr : grad_.data(); }
+    unsigned int NCalls() const override { return nCalls_; }
+    unsigned int NDim() const override { return nDim_; }
+    unsigned int NFree() const override { return nFree_; }
+
+    bool ProvidesError() const override { return true; }
+    const double * Errors() const override { return err_.empty() ? nullptr : err_.data(); }
+    double CovMatrix(unsigned int i, unsigned int j) const override {
+        return cov_.empty() ? 0.0 : cov_[i*nDim_+j];
+    }
+
+    bool ProvidesGradient() const override { return true; }
+    bool ProvidesHessian() const override { return true; }
+
+    void Gradient(const double *x, double *grad) const;
+    void Hessian(const double *x, double *hes) const;
+
+private:
+    struct CostFunction : public ceres::CostFunction {
+        CostFunction(const ROOT::Math::IMultiGradFunction *f);
+        bool Evaluate(double const* const* parameters, double *residuals, double **jacobians) const override;
+        const ROOT::Math::IMultiGradFunction *func;
+    };
+
+    const ROOT::Math::IMultiGenFunction *func_;
+    const ROOT::Math::IMultiGradFunction *gradFunc_;
+    unsigned int nDim_;
+    unsigned int nFree_;
+    unsigned int nCalls_;
+
+    std::vector<double> x_;
+    std::vector<double> step_;
+    std::vector<double> lower_;
+    std::vector<double> upper_;
+    std::vector<bool>   isFixed_;
+
+    std::vector<double> grad_;
+    std::vector<double> hess_;
+    std::vector<double> cov_;
+    std::vector<double> err_;
+
+    double fMinVal_;
+    double edm_;
+
+    double numDiffStep_;
+    bool forceNumeric_;
+};
+
+#endif

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -12,6 +12,7 @@
 #include <RooNumIntConfig.h>
 #include <TStopwatch.h>
 #include <RooStats/RooStatsUtils.h>
+#include <TSystem.h>
 
 #include <iomanip>
 
@@ -41,6 +42,7 @@ std::map<std::string,std::vector<std::string> > const CascadeMinimizer::minimize
  {"Minuit"	 ,{"Migrad","Simplex","Combined","Scan"}}
 ,{"Minuit2" 	 ,{"Migrad","Simplex","Combined","Scan"}}
 ,{"GSLMultiMin"  ,{"ConjugateFR", "ConjugatePR", "BFGS", "BFGS2", "SteepestDescent"}}
+ ,{"Ceres"        ,{"TrustRegion","LineSearch"}}
 };
 
 CascadeMinimizer::CascadeMinimizer(RooAbsReal &nll, Mode mode, RooRealVar *poi) :
@@ -718,8 +720,8 @@ void CascadeMinimizer::initOptions()
         ("cminOldRobustMinimize", boost::program_options::value<bool>(&oldFallback_)->default_value(oldFallback_), "Use the old 'robustMinimize' logic in addition to the cascade (for debug only)")
         ("cminInitialHesse", boost::program_options::value<bool>(&firstHesse_)->default_value(firstHesse_), "Call Hesse before the minimization")
         ("cminFinalHesse", boost::program_options::value<bool>(&lastHesse_)->default_value(lastHesse_), "Call Hesse after the minimization")
-	("cminDefaultMinimizerType",boost::program_options::value<std::string>(&defaultMinimizerType_)->default_value(defaultMinimizerType_), "Set the default minimizer Type")
-	("cminDefaultMinimizerAlgo",boost::program_options::value<std::string>(&defaultMinimizerAlgo_)->default_value(defaultMinimizerAlgo_), "Set the default minimizer Algo")
+        ("cminDefaultMinimizerType",boost::program_options::value<std::string>(&defaultMinimizerType_)->default_value(defaultMinimizerType_), "Set the default minimizer Type (e.g. Minuit2, Minuit, GSLMultiMin, Ceres)")
+        ("cminDefaultMinimizerAlgo",boost::program_options::value<std::string>(&defaultMinimizerAlgo_)->default_value(defaultMinimizerAlgo_), "Set the default minimizer Algo (e.g. Migrad, Simplex, TrustRegion)")
 	("cminDefaultMinimizerTolerance",boost::program_options::value<double>(&defaultMinimizerTolerance_)->default_value(defaultMinimizerTolerance_), "Set the default minimizer Tolerance")
 	("cminDefaultMinimizerPrecision",boost::program_options::value<double>(&defaultMinimizerPrecision_)->default_value(defaultMinimizerPrecision_), "Set the default minimizer precision")
 	("cminDefaultMinimizerStrategy",boost::program_options::value<int>(&strategy_)->default_value(strategy_), "Set the default minimizer (initial) strategy")
@@ -766,8 +768,11 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
     if (vm.count("cminDefaultMinimizerAlgo")){
       if (! checkAlgoInType(defaultMinimizerType_,defaultMinimizerAlgo_)) {
       // severe enough to print to terminal
-	    std::cerr << Form("The combination of minimizer type/algo %s/%s, is not recognized. Please set these with --cminDefaultMinimizerType and --cminDefaultMinimizerAlgo",defaultMinimizerType_.c_str(),defaultMinimizerAlgo_.c_str());
-	    exit(0);
+            std::cerr << Form("The combination of minimizer type/algo %s/%s, is not recognized. Please set these with --cminDefaultMinimizerType and --cminDefaultMinimizerAlgo",defaultMinimizerType_.c_str(),defaultMinimizerAlgo_.c_str());
+            exit(0);
+      }
+      if (defaultMinimizerType_ == "Ceres") {
+          gSystem->Load("libCeresMinimizer");
       }
     }
 


### PR DESCRIPTION
## Summary
- Implement Ceres-based ROOT minimizer with gradient/Hessian hooks and plugin registration
- Allow selecting Ceres with `--cminDefaultMinimizerType` and choose `TrustRegion` or `LineSearch` algorithms
- Integrate Ceres into build system and document runtime usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68b4669429b08329937ca2f54b4b426a