### PR TITLE
Compute full Hessian in Ceres minimizer

### DIFF
--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -45,6 +45,8 @@ public:
     void Hessian(const double *x, double *hes) const;
 
 private:
+    void ComputeGradientAndHessian(const double *x);
+
     struct CostFunction : public ceres::CostFunction {
         CostFunction(const ROOT::Math::IMultiGradFunction *f);
         bool Evaluate(double const* const* parameters, double *residuals, double **jacobians) const override;


### PR DESCRIPTION
## Summary
- Replace diagonal-only finite difference loop with helper computing full Hessian via repeated gradient evaluations
- Use new helper to populate gradient and covariance including off-diagonal terms

## Testing
- `make` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4908acc888329a5d367cdb04b160a