### PR TITLE
Handle missing Ceres minimizer plugin

### DIFF
--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -17,6 +17,7 @@
 #include <iomanip>
 #include <cstdlib>
 #include <set>
+#include <stdexcept>
 
 boost::program_options::options_description CascadeMinimizer::options_("Cascade Minimizer options");
 std::vector<CascadeMinimizer::Algo> CascadeMinimizer::fallbacks_;
@@ -866,7 +867,11 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
         defaultMinimizerAlgo_ = algo;
     }
     if (defaultMinimizerType_ == "Ceres") {
-        gSystem->Load("libCeresMinimizer");
+        int loadStatus = gSystem->Load("libCeresMinimizer");
+        if (loadStatus < 0) {
+            CombineLogger::instance().log("CascadeMinimizer.cc",__LINE__,"[FATAL] Failed to load libCeresMinimizer. Rebuild with Ceres support or choose a supported minimizer.",__func__);
+            throw std::runtime_error("Failed to load libCeresMinimizer");
+        }
         setenv("CERES_ALGO", defaultMinimizerAlgo_.c_str(), 1);
     }
     // Note that the options are not applied again when recreating a CascadeMinimizer so need to set the global attributes (should we make the modifiable options persistant too?)

--- a/test/unit/testCeresLoadFailure.cxx
+++ b/test/unit/testCeresLoadFailure.cxx
@@ -1,0 +1,17 @@
+#include <boost/program_options.hpp>
+#include "../../interface/CascadeMinimizer.h"
+#include <iostream>
+
+int main() {
+    using namespace boost::program_options;
+    variables_map vm;
+    vm.insert(std::make_pair("cminDefaultMinimizerType", variable_value(std::string("Ceres"), false)));
+    try {
+        CascadeMinimizer::applyOptions(vm);
+    } catch (const std::runtime_error &e) {
+        std::cout << "Caught expected error: " << e.what() << std::endl;
+        return 0;
+    }
+    std::cerr << "Expected failure to load Ceres minimizer plugin" << std::endl;
+    return 1;
+}


### PR DESCRIPTION
## Summary
- detect and report failure to load the Ceres minimizer plugin
- add integration test covering missing Ceres plugin path

## Testing
- `make -C test/unit testCeresLoadFailure.exe` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b49aa199ac832989359748a08eba74