### PR TITLE
build: add optional Ceres minimizer plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,22 @@ OBJS = $(SRCS:.cc=.o)
 OBJS += $(SRXS:.cxx=.o)
 PROGS = $(notdir $(wildcard ${PROG_DIR}/*.cpp)) 
 EXES = $(PROGS:.cpp=)
-SCRIPTS = $(notdir $(wildcard ${SCRIPTS_DIR}/*.py)) 
+SCRIPTS = $(notdir $(wildcard ${SCRIPTS_DIR}/*.py))
 PYLIB_DIR = $(LIB_DIR)/python
+
+# Optional Ceres minimizer plugin ---------------------------------------------
+ifdef CERES
+CERES_OBJ = $(OBJ_DIR)/CeresMinimizer.o
+CERES_SO  = $(LIB_DIR)/libCeresMinimizer.so
+# allow includes and linking from conda or custom installs
+CERES_INC = $(if $(CONDA_PREFIX),-I${CONDA_PREFIX}/include,)
+CERES_LIB = $(if $(CONDA_PREFIX),-L${CONDA_PREFIX}/lib,) -lceres
+endif
 
 #Makefile Rules ---------------------------------------------------------------
 .PHONY: clean exe python
 
-all: exe python
+all: exe python $(CERES_SO)
 
 #---------------------------------------
 
@@ -124,7 +133,17 @@ $(LIB_DIR):
 	@mkdir -p $(LIB_DIR)
 
 ${LIB_DIR}/$(SONAME): $(addprefix $(OBJ_DIR)/,$(OBJS)) $(OBJ_DIR)/a/$(DICTNAME).o | $(LIB_DIR)
-	$(LD) $(LDFLAGS) $(BOOST_INC) $^ $(SOFLAGS) -o $@ $(LIBS)
+        $(LD) $(LDFLAGS) $(BOOST_INC) $^ $(SOFLAGS) -o $@ $(LIBS)
+
+#---------------------------------------
+
+ifdef CERES
+$(CERES_OBJ): ceres/CeresMinimizer.cc $(INC_DIR)/CeresMinimizer.h | $(OBJ_DIR)
+        $(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) $(CERES_INC) -c $< -o $@
+
+$(CERES_SO): $(CERES_OBJ) | $(LIB_DIR)
+        $(CXX) -shared -fPIC -o $@ $^ $(CERES_LIB) $(ROOTLIBS)
+endif
 
 #---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The source code of this documentation can be found in the `docs/` folder in this
 ### Ceres minimizer plugin
 
 The build system optionally integrates the [Ceres Solver](http://ceres-solver.org) as a ROOT minimizer. When Ceres is available the
-`libCeresMinimizer` plugin is built automatically. The plugin can be selected at runtime when calling `combine` and supports both
+`libCeresMinimizer` plugin is built automatically. When using the standalone `Makefile` build, enable it with `CERES=1` (e.g. `make CONDA=1 CERES=1`). The plugin can be selected at runtime when calling `combine` and supports both
 the `TrustRegion` and `LineSearch` algorithms. Use `--cminCeresAlgo` to choose the algorithm explicitly. Available linear solvers include `dense_qr`, `dense_normal_cholesky`, `iterative_schur`, `sparse_normal_cholesky`, `dense_schur` and `sparse_schur`:
 
 ```


### PR DESCRIPTION
## Summary
- compile Ceres minimizer wrapper into libCeresMinimizer.so when `CERES=1`
- document how to enable the plugin in the Makefile-based build

## Testing
- `make CONDA=1 CERES=1 -j2` *(fails: `root-config: No such file or directory`)*
- `sudo apt-get update` *(fails: repository 403 `InRelease` not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e6d34bc8329a50c9bd4766ef264