### PR TITLE
build: compile Ceres minimizer plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,22 @@ OBJS = $(SRCS:.cc=.o)
 OBJS += $(SRXS:.cxx=.o)
 PROGS = $(notdir $(wildcard ${PROG_DIR}/*.cpp)) 
 EXES = $(PROGS:.cpp=)
-SCRIPTS = $(notdir $(wildcard ${SCRIPTS_DIR}/*.py)) 
+SCRIPTS = $(notdir $(wildcard ${SCRIPTS_DIR}/*.py))
 PYLIB_DIR = $(LIB_DIR)/python
+
+# Ceres minimizer plugin ------------------------------------------------------
+CERES_LIBNAME = CeresMinimizer
+CERES_SONAME  = lib$(CERES_LIBNAME).so
+CERES_SRC     = ceres/CeresMinimizer.cc
+CERES_OBJ     = $(OBJ_DIR)/CeresMinimizer.o
+# allow includes and linking from conda or custom installs
+CERES_INC     = $(if $(CONDA_PREFIX),-I${CONDA_PREFIX}/include,)
+CERES_LIB     = $(if $(CONDA_PREFIX),-L${CONDA_PREFIX}/lib,) -lceres
 
 #Makefile Rules ---------------------------------------------------------------
 .PHONY: clean exe python
 
-all: exe python
+all: exe python $(LIB_DIR)/$(CERES_SONAME)
 
 #---------------------------------------
 
@@ -125,6 +134,15 @@ $(LIB_DIR):
 
 ${LIB_DIR}/$(SONAME): $(addprefix $(OBJ_DIR)/,$(OBJS)) $(OBJ_DIR)/a/$(DICTNAME).o | $(LIB_DIR)
 	$(LD) $(LDFLAGS) $(BOOST_INC) $^ $(SOFLAGS) -o $@ $(LIBS)
+
+#---------------------------------------
+
+
+$(CERES_OBJ): $(CERES_SRC) $(INC_DIR)/CeresMinimizer.h | $(OBJ_DIR)
+	$(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) $(CERES_INC) -c $< -o $@
+
+$(LIB_DIR)/$(CERES_SONAME): $(CERES_OBJ) | $(LIB_DIR)
+	$(CXX) -shared -fPIC -o $@ $^ $(CERES_LIB) $(ROOTLIBS)
 
 #---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The source code of this documentation can be found in the `docs/` folder in this
 
 ### Ceres minimizer plugin
 
-The build system optionally integrates the [Ceres Solver](http://ceres-solver.org) as a ROOT minimizer. When Ceres is available the
-`libCeresMinimizer` plugin is built automatically. The plugin can be selected at runtime when calling `combine` and supports both
+The build system integrates the [Ceres Solver](http://ceres-solver.org) as a ROOT minimizer. When the Ceres headers and libraries are available,
+`libCeresMinimizer` is built automatically alongside the project. The plugin can be selected at runtime when calling `combine` and supports both
 the `TrustRegion` and `LineSearch` algorithms. Use `--cminCeresAlgo` to choose the algorithm explicitly. Available linear solvers include `dense_qr`, `dense_normal_cholesky`, `iterative_schur`, `sparse_normal_cholesky`, `dense_schur` and `sparse_schur`:
 
 ```


### PR DESCRIPTION
## Summary
- always build libCeresMinimizer.so alongside the main library
- document automatic Ceres plugin build

## Testing
- `make -n build/lib/libCeresMinimizer.so` *(fails: `root-config` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e6d34bc8329a50c9bd4766ef264