### PR TITLE
Fix Ceres minimizer header for new ROOT gradient interface

### DIFF
--- a/ceres/CeresMinimizer.cc
+++ b/ceres/CeresMinimizer.cc
@@ -34,7 +34,7 @@ void CeresMinimizer::Clear() {
 
 void CeresMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction &func) {
     func_ = &func;
-    gradFunc_ = dynamic_cast<const ROOT::Math::IMultiGradFunction*>(func_);
+    gradFunc_ = dynamic_cast<const RootIMultiGradFunction*>(func_);
     nDim_ = func.NDim();
     nFree_ = nDim_;
     x_.assign(nDim_,0.0);
@@ -59,7 +59,7 @@ bool CeresMinimizer::SetFixedVariable(unsigned int i, const std::string &, doubl
     x_[i]=val; isFixed_[i]=true; nFree_--; return true;
 }
 
-CeresMinimizer::CostFunction::CostFunction(const ROOT::Math::IMultiGradFunction *f) : func(f) {
+CeresMinimizer::CostFunction::CostFunction(const RootIMultiGradFunction *f) : func(f) {
     set_num_residuals(1);
     mutable_parameter_block_sizes()->push_back(f->NDim());
 }

--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -2,7 +2,13 @@
 #define HiggsAnalysis_CombinedLimit_CeresMinimizer_h
 
 #include <Math/Minimizer.h>
+#if __has_include(<Math/IGradientFunctionMultiDim.h>)
+#include <Math/IGradientFunctionMultiDim.h>
+using RootIMultiGradFunction = ROOT::Math::IGradientFunctionMultiDim;
+#else
 #include <Math/IMultiGradFunction.h>
+using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;
+#endif
 #include <ceres/ceres.h>
 #include <string>
 #include <vector>
@@ -51,13 +57,13 @@ private:
     void ComputeGradientAndHessian(const double *x);
 
     struct CostFunction : public ceres::CostFunction {
-        CostFunction(const ROOT::Math::IMultiGradFunction *f);
+        CostFunction(const RootIMultiGradFunction *f);
         bool Evaluate(double const* const* parameters, double *residuals, double **jacobians) const override;
-        const ROOT::Math::IMultiGradFunction *func;
+        const RootIMultiGradFunction *func;
     };
 
     const ROOT::Math::IMultiGenFunction *func_;
-    const ROOT::Math::IMultiGradFunction *gradFunc_;
+    const RootIMultiGradFunction *gradFunc_;
     unsigned int nDim_;
     unsigned int nFree_;
     unsigned int nCalls_;


### PR DESCRIPTION
## Summary
- Support ROOT's renamed gradient interface in the Ceres minimizer

## Testing
- `make -j2` *(fails: `root-config: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a3cb5e5c832996e6615dfdcb207b