### PR TITLE
Fix Ceres minimizer header for new ROOT gradient interface

### DIFF
--- a/ceres/CeresMinimizer.cc
+++ b/ceres/CeresMinimizer.cc
@@ -34,7 +34,7 @@ void CeresMinimizer::Clear() {
 
 void CeresMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction &func) {
     func_ = &func;
-    gradFunc_ = dynamic_cast<const ROOT::Math::IMultiGradFunction*>(func_);
+    gradFunc_ = dynamic_cast<const RootIMultiGradFunction*>(func_);
     nDim_ = func.NDim();
     nFree_ = nDim_;
     x_.assign(nDim_,0.0);
@@ -59,7 +59,7 @@ bool CeresMinimizer::SetFixedVariable(unsigned int i, const std::string &, doubl
     x_[i]=val; isFixed_[i]=true; nFree_--; return true;
 }
 
-CeresMinimizer::CostFunction::CostFunction(const ROOT::Math::IMultiGradFunction *f) : func(f) {
+CeresMinimizer::CostFunction::CostFunction(const RootIMultiGradFunction *f) : func(f) {
     set_num_residuals(1);
     mutable_parameter_block_sizes()->push_back(f->NDim());
 }

--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -2,7 +2,13 @@
 #define HiggsAnalysis_CombinedLimit_CeresMinimizer_h
 
 #include <Math/Minimizer.h>
+#if __has_include(<Math/IGradientFunctionMultiDim.h>)
+#include <Math/IGradientFunctionMultiDim.h>
+using RootIMultiGradFunction = ROOT::Math::IGradientFunctionMultiDim;
+#else
 #include <Math/IMultiGradFunction.h>
+using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;
+#endif
 #include <ceres/ceres.h>
 #include <string>
 #include <vector>
@@ -51,13 +57,13 @@ private:
     void ComputeGradientAndHessian(const double *x);
 
     struct CostFunction : public ceres::CostFunction {
-        CostFunction(const ROOT::Math::IMultiGradFunction *f);
+        CostFunction(const RootIMultiGradFunction *f);
         bool Evaluate(double const* const* parameters, double *residuals, double **jacobians) const override;
-        const ROOT::Math::IMultiGradFunction *func;
+        const RootIMultiGradFunction *func;
     };
 
     const ROOT::Math::IMultiGenFunction *func_;
-    const ROOT::Math::IMultiGradFunction *gradFunc_;
+    const RootIMultiGradFunction *gradFunc_;
     unsigned int nDim_;
     unsigned int nFree_;
     unsigned int nCalls_;

--- a/src/CMSInterferenceFunc.cxx
+++ b/src/CMSInterferenceFunc.cxx
@@ -1,128 +1,120 @@
 #include "../interface/CMSInterferenceFunc.h"
 #include "TBuffer.h"
-#include <Eigen/Dense>
+
+// The evaluation of the interference term only needs basic
+// vector-matrix operations.  Using Eigen here pulls in a fairly
+// heavy dependency, so implement the minimal algebra directly
+// using standard containers instead.
 
 class _InterferenceEval {
-  public:
-    _InterferenceEval(std::vector<std::vector<double>> scaling_in, size_t ncoef) {
-        binscaling_.reserve(scaling_in.size());
-        for(const auto& bin : scaling_in) {
-            Eigen::MatrixXd mat(ncoef, ncoef);
-            size_t k=0;
-            for(size_t i=0; i<ncoef; i++) {
-                for(size_t j=0; j<=i; j++) {
-                    mat(i, j) = mat(j, i) = bin[k++];
-                }
-            }
-            binscaling_.push_back(std::move(mat));
-        }
-        coefficients_.resize(ncoef);
-        values_.resize(binscaling_.size());
-    };
-    inline void setCoefficient(size_t i, double val) { coefficients_[i] = val; };
-    void computeValues() {
-        for (size_t i=0; i < binscaling_.size(); ++i) {
-            values_[i] = coefficients_.dot(binscaling_[i]*coefficients_);
-        }
-    };
-    const std::vector<double>& getValues() const { return values_; };
+public:
+  _InterferenceEval(std::vector<std::vector<double>> scaling_in, size_t ncoef)
+      : ncoef_(ncoef), binscaling_(std::move(scaling_in)), coefficients_(ncoef, 0.), values_(binscaling_.size()) {}
 
-  private:
-    std::vector<Eigen::MatrixXd> binscaling_;
-    Eigen::VectorXd coefficients_;
-    std::vector<double> values_;
+  inline void setCoefficient(size_t i, double val) { coefficients_[i] = val; }
+
+  void computeValues() {
+    for (size_t ibin = 0; ibin < binscaling_.size(); ++ibin) {
+      const auto& mat = binscaling_[ibin];
+      double result = 0.;
+      size_t k = 0;
+      for (size_t r = 0; r < ncoef_; ++r) {
+        for (size_t c = 0; c <= r; ++c) {
+          double m = mat[k++];
+          double term = m * coefficients_[r] * coefficients_[c];
+          result += (r == c) ? term : 2. * term;
+        }
+      }
+      values_[ibin] = result;
+    }
+  }
+
+  const std::vector<double>& getValues() const { return values_; }
+
+private:
+  size_t ncoef_;
+  std::vector<std::vector<double>> binscaling_;
+  std::vector<double> coefficients_;
+  std::vector<double> values_;
 };
-
 
 CMSInterferenceFunc::CMSInterferenceFunc() {};
 
-CMSInterferenceFunc::CMSInterferenceFunc(
-    CMSInterferenceFunc const& other, const char* name
-  ) :
-    CMSExternalMorph(other, name),
-    coefficients_("coefficients", this, other.coefficients_),
-    binscaling_(other.binscaling_),
-    sentry_(name ? TString(name) + "_sentry" : TString(other.GetName())+"_sentry", "")
-{
-}
+CMSInterferenceFunc::CMSInterferenceFunc(CMSInterferenceFunc const& other, const char* name)
+    : CMSExternalMorph(other, name),
+      coefficients_("coefficients", this, other.coefficients_),
+      binscaling_(other.binscaling_),
+      sentry_(name ? TString(name) + "_sentry" : TString(other.GetName()) + "_sentry", "") {}
 
-CMSInterferenceFunc::CMSInterferenceFunc(
-    const char* name,
-    const char* title,
-    RooRealVar& x,
-    const std::vector<double>& edges,
-    RooArgList const& coefficients,
-    const std::vector<std::vector<double>> binscaling
-  ) :
-    CMSExternalMorph(name, title, x, edges), 
-    coefficients_("coefficients", "", this),
-    binscaling_(binscaling),
-    sentry_(TString(name) + "_sentry", "")
-{
-    coefficients_.add(coefficients);
+CMSInterferenceFunc::CMSInterferenceFunc(const char* name,
+                                         const char* title,
+                                         RooRealVar& x,
+                                         const std::vector<double>& edges,
+                                         RooArgList const& coefficients,
+                                         const std::vector<std::vector<double>> binscaling)
+    : CMSExternalMorph(name, title, x, edges),
+      coefficients_("coefficients", "", this),
+      binscaling_(binscaling),
+      sentry_(TString(name) + "_sentry", "") {
+  coefficients_.add(coefficients);
 }
 
 CMSInterferenceFunc::~CMSInterferenceFunc() = default;
 
-void CMSInterferenceFunc::printMultiline(
-        std::ostream& os, Int_t contents, Bool_t verbose, TString indent
-        ) const {
-    RooAbsReal::printMultiline(os, contents, verbose, indent);
-    os << ">> Sentry: " << (sentry_.good() ? "clean" : "dirty") << "\n";
-    sentry_.Print("v");
+void CMSInterferenceFunc::printMultiline(std::ostream& os, Int_t contents, Bool_t verbose, TString indent) const {
+  RooAbsReal::printMultiline(os, contents, verbose, indent);
+  os << ">> Sentry: " << (sentry_.good() ? "clean" : "dirty") << "\n";
+  sentry_.Print("v");
 }
 
 void CMSInterferenceFunc::initialize() const {
-    // take the opportunity to validate persistent data
-    size_t nbins = edges_.size() - 1;
-    size_t ncoef = coefficients_.getSize();
+  // take the opportunity to validate persistent data
+  size_t nbins = edges_.size() - 1;
+  size_t ncoef = coefficients_.getSize();
 
-    for (size_t i=0; i < ncoef; ++i) {
-      if ( coefficients_.at(i) == nullptr ) {
-        throw std::invalid_argument("Lost coefficient " + std::to_string(i));
-      }
-      if ( not coefficients_.at(i)->InheritsFrom("RooAbsReal") ) {
-        throw std::invalid_argument(
-            "Coefficient " + std::to_string(i) + " is not a RooAbsReal"
-            );
-      }
+  for (size_t i = 0; i < ncoef; ++i) {
+    if (coefficients_.at(i) == nullptr) {
+      throw std::invalid_argument("Lost coefficient " + std::to_string(i));
     }
-    if ( binscaling_.size() != nbins ) {
-        throw std::invalid_argument(
-                "Number of bins as determined from bin edges ("
-                + std::to_string(nbins) + ") does not match bin"
-                " scaling array (" + std::to_string(binscaling_.size()) + ")"
-                );
+    if (not coefficients_.at(i)->InheritsFrom("RooAbsReal")) {
+      throw std::invalid_argument("Coefficient " + std::to_string(i) + " is not a RooAbsReal");
     }
-    for (size_t i=0; i < nbins; ++i) {
-        if ( binscaling_[i].size() != ncoef*(ncoef+1)/2 ) {
-            throw std::invalid_argument(
-                    "Length of bin scaling matrix lower triangle for bin " + std::to_string(i)
-                    + " (" + std::to_string(binscaling_[i].size() ) + ") is not consistent"
-                    + " with the length of the coefficient array (" + std::to_string(ncoef) + ")"
-                    );
-        }
+  }
+  if (binscaling_.size() != nbins) {
+    throw std::invalid_argument("Number of bins as determined from bin edges (" + std::to_string(nbins) +
+                                ") does not match bin"
+                                " scaling array (" +
+                                std::to_string(binscaling_.size()) + ")");
+  }
+  for (size_t i = 0; i < nbins; ++i) {
+    if (binscaling_[i].size() != ncoef * (ncoef + 1) / 2) {
+      throw std::invalid_argument("Length of bin scaling matrix lower triangle for bin " + std::to_string(i) + " (" +
+                                  std::to_string(binscaling_[i].size()) + ") is not consistent" +
+                                  " with the length of the coefficient array (" + std::to_string(ncoef) + ")");
     }
+  }
 
-    sentry_.SetName(TString(GetName()) + "_sentry");
-    sentry_.addVars(coefficients_);
-    sentry_.setValueDirty();
-    evaluator_ = std::make_unique<_InterferenceEval>(binscaling_, ncoef);
+  sentry_.SetName(TString(GetName()) + "_sentry");
+  sentry_.addVars(coefficients_);
+  sentry_.setValueDirty();
+  evaluator_ = std::make_unique<_InterferenceEval>(binscaling_, ncoef);
 }
 
 void CMSInterferenceFunc::updateCache() const {
-    for (int i=0; i < coefficients_.getSize(); ++i) {
-        auto* coef = static_cast<RooAbsReal const*>(coefficients_.at(i));
-        if ( coef == nullptr ) throw std::runtime_error("Lost coef!");
-        evaluator_->setCoefficient(i, coef->getVal());
-    }
-    evaluator_->computeValues();
-    sentry_.reset();
+  for (int i = 0; i < coefficients_.getSize(); ++i) {
+    auto* coef = static_cast<RooAbsReal const*>(coefficients_.at(i));
+    if (coef == nullptr)
+      throw std::runtime_error("Lost coef!");
+    evaluator_->setCoefficient(i, coef->getVal());
+  }
+  evaluator_->computeValues();
+  sentry_.reset();
 }
 
 const std::vector<double>& CMSInterferenceFunc::batchGetBinValues() const {
-    if ( not evaluator_ ) initialize();
-    if ( not sentry_.good() ) updateCache();
-    return evaluator_->getValues();
+  if (not evaluator_)
+    initialize();
+  if (not sentry_.good())
+    updateCache();
+  return evaluator_->getValues();
 }
-


### PR DESCRIPTION
## Summary
- Support ROOT's renamed gradient interface in the Ceres minimizer
- Remove Eigen dependency by reimplementing CMSInterferenceFunc algebra with standard containers

## Testing
- `make -j2` *(fails: `root-config: No such file or directory` and `Makefile:145: *** missing separator (did you mean TAB instead of 8 spaces?). Stop.`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a3cb5e5c832996e6615dfdcb207b