### PR TITLE
Update Ceres minimizer headers for ROOT 6.30+

### DIFF
--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -2,9 +2,13 @@
 #define HiggsAnalysis_CombinedLimit_CeresMinimizer_h
 
 #include <Math/Minimizer.h>
+#include <Fit/ParameterSettings.h>
 #if __has_include(<Math/IGradientFunctionMultiDim.h>)
 #include <Math/IGradientFunctionMultiDim.h>
 using RootIMultiGradFunction = ROOT::Math::IGradientFunctionMultiDim;
+#elif __has_include(<Math/IFunction.h>)
+#include <Math/IFunction.h>
+using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;
 #else
 #include <Math/IMultiGradFunction.h>
 using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;


### PR DESCRIPTION
## Summary
- include new ROOT headers and fallback to IMultiGradFunction
- support builds with ROOT >=6.30 by checking for Math/IFunction.h

## Testing
- `make CONDA=1 CERES=1 -j$(nproc)` *(fails: `root-config: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a8536acc83298a0406c402682df6