### PR TITLE
Link glog/gflags in Ceres plugin build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,21 +94,19 @@ CERES_SRC     = ceres/CeresMinimizer.cc
 CERES_OBJ     = $(OBJ_DIR)/CeresMinimizer.o
 # allow includes and linking from conda or custom installs
 CERES_INC     = $(if $(CONDA_PREFIX),-I${CONDA_PREFIX}/include,)
-CERES_LIB     = $(if $(CONDA_PREFIX),-L${CONDA_PREFIX}/lib,) -lceres
-# Optional Ceres minimizer plugin ---------------------------------------------
-ifdef CERES
-CERES_OBJ = $(OBJ_DIR)/CeresMinimizer.o
-CERES_SO  = $(LIB_DIR)/libCeresMinimizer.so
-# allow includes and linking from conda or custom installs
-CERES_INC = $(if $(CONDA_PREFIX),-I${CONDA_PREFIX}/include,)
-CERES_LIB = $(if $(CONDA_PREFIX),-L${CONDA_PREFIX}/lib,) -lceres
-endif
+CERES_LIB     = $(if $(CONDA_PREFIX),-L${CONDA_PREFIX}/lib,) -lceres -lglog -lgflags
+# glog headers from conda need explicit macros when not using CMake
+# define gflags usage and disable symbol export decoration
+CERES_DEFS    = -DGLOG_USE_GFLAGS -DGLOG_EXPORT= -DGLOG_NO_EXPORT
 
 #Makefile Rules ---------------------------------------------------------------
 .PHONY: clean exe python
 
-all: exe python $(LIB_DIR)/$(CERES_SONAME)
-all: exe python $(CERES_SO)
+all: exe python
+ifdef CERES
+all: $(LIB_DIR)/$(CERES_SONAME)
+CCFLAGS += $(CERES_INC) $(CERES_DEFS)
+endif
 
 #---------------------------------------
 
@@ -147,21 +145,14 @@ ${LIB_DIR}/$(SONAME): $(addprefix $(OBJ_DIR)/,$(OBJS)) $(OBJ_DIR)/a/$(DICTNAME).
 #---------------------------------------
 
 ifdef CERES
-$(CERES_OBJ): ceres/CeresMinimizer.cc $(INC_DIR)/CeresMinimizer.h | $(OBJ_DIR)
-	$(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) $(CERES_INC) -c $< -o $@
-
-$(CERES_SO): $(CERES_OBJ) | $(LIB_DIR)
-	$(CXX) -shared -fPIC -o $@ $^ $(CERES_LIB) $(ROOTLIBS)
-endif
-
-#---------------------------------------
-
 
 $(CERES_OBJ): $(CERES_SRC) $(INC_DIR)/CeresMinimizer.h | $(OBJ_DIR)
-	$(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) $(CERES_INC) -c $< -o $@
+	$(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) -c $< -o $@
 
 $(LIB_DIR)/$(CERES_SONAME): $(CERES_OBJ) | $(LIB_DIR)
 	$(CXX) -shared -fPIC -o $@ $^ $(CERES_LIB) $(ROOTLIBS)
+
+endif
 
 #---------------------------------------
 

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -13,3 +13,5 @@ dependencies:
   - pcre
   - eigen
   - ceres-solver
+  - gflags
+  - glog

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,6 +190,8 @@ conda deactivate
 conda activate combine
 
 make CONDA=1 -j 8
+# build with optional Ceres minimizer plugin
+make CONDA=1 CERES=1 -j 8
 ```
 
 Using <span style="font-variant:small-caps;">Combine</span> from then on should only require sourcing the conda environment 


### PR DESCRIPTION
## Summary
- Link Ceres plugin against glog and gflags and define required glog macros
- Add glog and gflags to conda environment
- Document optional Ceres build step in conda instructions
- Define empty `GLOG_EXPORT` macro so glog 0.7 headers compile without CMake

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'six')*

------
https://chatgpt.com/codex/tasks/task_e_68b4aa82b778832997b9fd32318eda96