### PR TITLE
Fix glog usage for Ceres build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ CERES_OBJ     = $(OBJ_DIR)/CeresMinimizer.o
 CERES_INC     = $(if $(CONDA_PREFIX),-I${CONDA_PREFIX}/include,)
 CERES_LIB     = $(if $(CONDA_PREFIX),-L${CONDA_PREFIX}/lib,) -lceres -lglog -lgflags
 # glog headers from conda need explicit definitions when not using CMake
-CERES_DEFS    = -DGLOG_USE_GFLAGS -DGLOG_NO_EXPORT
+# glog >=0.7 requires explicit opt-in when consuming headers directly
+CERES_DEFS    = -DGLOG_USE_GLOG_EXPORT -DGLOG_USE_GFLAGS
 
 #Makefile Rules ---------------------------------------------------------------
 .PHONY: clean exe python


### PR DESCRIPTION
## Summary
- Define `GLOG_USE_GLOG_EXPORT` and keep `GLOG_USE_GFLAGS` when building optional Ceres minimizer plugin.
- Update comment explaining glog >=0.7 header requirements.

## Testing
- `make clean`
- `make CERES=1` *(fails: `root-config: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4af90c4608329a2a206004a76a74b