### PR TITLE
Fix Ceres minimizer for updated ROOT and Ceres APIs

### DIFF
--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -13,6 +13,7 @@ using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;
 #include <string>
 #include <vector>
 #include <memory>
+#include <RVersion.h>
 
 /// Minimizer interface using Ceres Solver
 class CeresMinimizer : public ROOT::Math::Minimizer {
@@ -20,7 +21,13 @@ public:
     CeresMinimizer(const char *name = nullptr);
     ~CeresMinimizer() override;
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,30,0)
+    std::string GetName() const override { return "Ceres"; }
+#else
     const char * Name() const override { return "Ceres"; }
+    bool ProvidesGradient() const override { return true; }
+    bool ProvidesHessian() const override { return true; }
+#endif
 
     void Clear() override;
     void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
@@ -46,9 +53,6 @@ public:
         if (cov_.empty() || i >= nDim_ || j >= nDim_) return 0.0;
         return cov_[i*nDim_ + j];
     }
-
-    bool ProvidesGradient() const override { return true; }
-    bool ProvidesHessian() const override { return true; }
 
     void Gradient(const double *x, double *grad) const;
     void Hessian(const double *x, double *hes) const;


### PR DESCRIPTION
## Summary
- adapt Ceres minimizer to ROOT 6.30+ by using `GetName()` and guarding old interfaces
- replace deprecated `NumericDiffCostFunction` and removed `Hessian` access with custom numeric implementation

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'ROOT')*
- `make CONDA=1 CERES=1 -j2` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b05a68048329a04fd5aef0e8b533