### PR TITLE
Fix Ceres minimizer naming for old ROOT

### DIFF
--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -23,10 +23,14 @@ public:
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,30,0)
     std::string GetName() const override { return "Ceres"; }
-#else
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,24,0)
     const char * Name() const override { return "Ceres"; }
     bool ProvidesGradient() const override { return true; }
     bool ProvidesHessian() const override { return true; }
+#else
+    const char * Name() const { return "Ceres"; }
+    bool ProvidesGradient() const { return true; }
+    bool ProvidesHessian() const { return true; }
 #endif
 
     void Clear() override;


### PR DESCRIPTION
## Summary
- make Ceres minimizer compatible with older ROOT versions by only overriding naming and gradient methods when the base class provides them

## Testing
- `make ceres/CeresMinimizer.o` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b1b890888329a113bd4f74d231ec