### PR TITLE
Expose default minimizer settings via accessors

### DIFF
--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -36,9 +36,10 @@ class CascadeMinimizer {
         //void collectIrrelevantNuisances(RooAbsCollection &irrelevant) const ;
 	bool freezeDiscParams(const bool);
         void setAutoBounds(const RooArgSet *pois) ;
-        void setAutoMax(const RooArgSet *pois) ; 
-	double tolerance() {return defaultMinimizerTolerance_;};
-	std::string algo() {return defaultMinimizerAlgo_;};
+        void setAutoMax(const RooArgSet *pois) ;
+        double tolerance() {return defaultMinimizerTolerance_;};
+        std::string algo() {return defaultMinimizerAlgo_;};
+        std::string type() {return defaultMinimizerType_;};
     private:
         RooAbsReal & nll_;
         std::unique_ptr<RooMinimizer> minimizer_;

--- a/src/AsymptoticLimits.cc
+++ b/src/AsymptoticLimits.cc
@@ -625,7 +625,7 @@ float AsymptoticLimits::findExpectedLimitFromCrossing(
     minim.minimize(verbose - 2);
     sentry.clear();
     std::string minAlgo = ROOT::Math::MinimizerOptions::DefaultMinimizerType() == std::string("Ceres")
-                              ? CascadeMinimizer::defaultMinimizerType_ + "," + CascadeMinimizer::defaultMinimizerAlgo_
+                              ? minim.type() + "," + minim.algo()
                               : ROOT::Math::MinimizerOptions::DefaultMinimizerType() + "," +
                                     ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
     Significance::MinimizerSentry minimizerConfig(minAlgo, ROOT::Math::MinimizerOptions::DefaultTolerance());

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -310,7 +310,7 @@ bool CascadeMinimizer::minos(const RooArgSet &params, int verbose) {
   {
     std::string minAlgo =
         (myType == std::string("Ceres")) ? defaultMinimizerType_ + "," + defaultMinimizerAlgo_ : myType + "," + myAlgo;
-    Significance::MinimizerSentry minimizerConfig(minAlgo, minimizer_->tolerance());
+    Significance::MinimizerSentry minimizerConfig(minAlgo, ROOT::Math::MinimizerOptions::DefaultTolerance());
     iret = minimizer_->minos(params);
   }
   if (iret == 0) {


### PR DESCRIPTION
## Summary
- add public accessors for the default minimizer type, algorithm and tolerance in `CascadeMinimizer`
- update `AsymptoticLimits` to query minimizer configuration via these accessors
- use `ROOT::Math::MinimizerOptions::DefaultTolerance()` instead of nonexistent `RooMinimizer::tolerance()` in `CascadeMinimizer::minos`

## Testing
- `make build/obj/CascadeMinimizer.o -j4` *(fails: root-config not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b96c38688329963ac7518ca478f9