### PR TITLE
Improve Ceres configuration logging and diff method handling

### DIFF
--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -18,80 +18,84 @@ using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;
 /// Minimizer interface using Ceres Solver
 class CeresMinimizer : public ROOT::Math::Minimizer {
 public:
-    CeresMinimizer(const char *name = nullptr);
-    ~CeresMinimizer() override;
+  CeresMinimizer(const char *name = nullptr);
+  ~CeresMinimizer() override;
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,30,0)
-    std::string GetName() const override { return "Ceres"; }
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,24,0)
-    const char * Name() const override { return "Ceres"; }
-    bool ProvidesGradient() const override { return true; }
-    bool ProvidesHessian() const override { return true; }
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 30, 0)
+  std::string Name() const override { return "Ceres"; }
+  bool ProvidesGradient() const override { return true; }
+  bool ProvidesHessian() const override { return true; }
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6, 24, 0)
+  const char *Name() const override { return "Ceres"; }
+  bool ProvidesGradient() const override { return true; }
+  bool ProvidesHessian() const override { return true; }
 #else
-    const char * Name() const { return "Ceres"; }
-    bool ProvidesGradient() const { return true; }
-    bool ProvidesHessian() const { return true; }
+  const char *Name() const { return "Ceres"; }
+  bool ProvidesGradient() const { return true; }
+  bool ProvidesHessian() const { return true; }
 #endif
 
-    void Clear() override;
-    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
+  void Clear() override;
+  void SetFunction(const ROOT::Math::IMultiGenFunction &func) override;
 
-    bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
-    bool SetLimitedVariable(unsigned int ivar, const std::string & name, double val, double step, double lower, double upper) override;
-    bool SetFixedVariable(unsigned int ivar, const std::string & name, double val) override;
+  bool SetVariable(unsigned int ivar, const std::string &name, double val, double step) override;
+  bool SetLimitedVariable(
+      unsigned int ivar, const std::string &name, double val, double step, double lower, double upper) override;
+  bool SetFixedVariable(unsigned int ivar, const std::string &name, double val) override;
 
-    bool Minimize() override;
+  bool Minimize() override;
 
-    double MinValue() const override { return fMinVal_; }
-    double Edm() const override { return edm_; }
+  double MinValue() const override { return fMinVal_; }
+  double Edm() const override { return edm_; }
 
-    const double * X() const override { return x_.data(); }
-    const double * MinGradient() const override { return grad_.empty() ? nullptr : grad_.data(); }
-    unsigned int NCalls() const override { return nCalls_; }
-    unsigned int NDim() const override { return nDim_; }
-    unsigned int NFree() const override { return nFree_; }
+  const double *X() const override { return x_.data(); }
+  const double *MinGradient() const override { return grad_.empty() ? nullptr : grad_.data(); }
+  unsigned int NCalls() const override { return nCalls_; }
+  unsigned int NDim() const override { return nDim_; }
+  unsigned int NFree() const override { return nFree_; }
 
-    bool ProvidesError() const override { return true; }
-    const double * Errors() const override { return errors_.empty() ? nullptr : errors_.data(); }
-    double CovMatrix(unsigned int i, unsigned int j) const override {
-        if (cov_.empty() || i >= nDim_ || j >= nDim_) return 0.0;
-        return cov_[i*nDim_ + j];
-    }
+  bool ProvidesError() const override { return true; }
+  const double *Errors() const override { return errors_.empty() ? nullptr : errors_.data(); }
+  double CovMatrix(unsigned int i, unsigned int j) const override {
+    if (cov_.empty() || i >= nDim_ || j >= nDim_)
+      return 0.0;
+    return cov_[i * nDim_ + j];
+  }
 
-    void Gradient(const double *x, double *grad) const;
-    void Hessian(const double *x, double *hes) const;
+  void Gradient(const double *x, double *grad) const;
+  void Hessian(const double *x, double *hes) const;
 
 private:
-    void ComputeGradientAndHessian(const double *x);
+  void ComputeGradientAndHessian(const double *x);
 
-    struct CostFunction : public ceres::CostFunction {
-        CostFunction(const RootIMultiGradFunction *f);
-        bool Evaluate(double const* const* parameters, double *residuals, double **jacobians) const override;
-        const RootIMultiGradFunction *func;
-    };
+  struct CostFunction : public ceres::CostFunction {
+    CostFunction(const RootIMultiGradFunction *f);
+    bool Evaluate(double const *const *parameters, double *residuals, double **jacobians) const override;
+    const RootIMultiGradFunction *func;
+  };
 
-    const ROOT::Math::IMultiGenFunction *func_;
-    const RootIMultiGradFunction *gradFunc_;
-    unsigned int nDim_;
-    unsigned int nFree_;
-    unsigned int nCalls_;
+  const ROOT::Math::IMultiGenFunction *func_;
+  const RootIMultiGradFunction *gradFunc_;
+  unsigned int nDim_;
+  unsigned int nFree_;
+  unsigned int nCalls_;
 
-    std::vector<double> x_;
-    std::vector<double> step_;
-    std::vector<double> lower_;
-    std::vector<double> upper_;
-    std::vector<bool>   isFixed_;
+  std::vector<double> x_;
+  std::vector<double> step_;
+  std::vector<double> lower_;
+  std::vector<double> upper_;
+  std::vector<bool> isFixed_;
 
-    std::vector<double> grad_;
-    std::vector<double> hess_;
-    std::vector<double> cov_;
-    std::vector<double> errors_;
+  std::vector<double> grad_;
+  std::vector<double> hess_;
+  std::vector<double> cov_;
+  std::vector<double> errors_;
 
-    double fMinVal_;
-    double edm_;
+  double fMinVal_;
+  double edm_;
 
-    double numDiffStep_;
-    bool forceNumeric_;
+  double numDiffStep_;
+  bool forceNumeric_;
 };
 
 #endif

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -1072,15 +1072,6 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
   }
   ROOT::Math::MinimizerOptions::SetDefaultStrategy(strategy_);
 
-  CombineLogger::instance().log("CascadeMinimizer.cc",
-                                __LINE__,
-                                std::string(Form("Using minimizer %s with algorithm %s, strategy %d and tolerance %g",
-                                                 defaultMinimizerType_.c_str(),
-                                                 defaultMinimizerAlgo_.c_str(),
-                                                 strategy_,
-                                                 defaultMinimizerTolerance_)),
-                                __func__);
-
   // propagate Ceres specific options through environment variables
   if (vm.count("cminCeresMaxIterations")) {
     int val = vm["cminCeresMaxIterations"].as<int>();
@@ -1255,6 +1246,40 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
   }
   if (vm["cminCeresAutoThreads"].as<bool>()) {
     setenv("CERES_AUTO_THREADS", "1", 1);
+  }
+
+  // after applying all options, print a summary of the minimizer configuration
+  if (defaultMinimizerType_ == "Ceres") {
+    std::string fTol = getenv("CERES_FUNCTION_TOLERANCE")
+                           ? getenv("CERES_FUNCTION_TOLERANCE")
+                           : Form("%g", defaultMinimizerTolerance_);
+    std::string gTol = getenv("CERES_GRADIENT_TOLERANCE")
+                           ? getenv("CERES_GRADIENT_TOLERANCE")
+                           : fTol;
+    std::string pTol = getenv("CERES_PARAMETER_TOLERANCE")
+                           ? getenv("CERES_PARAMETER_TOLERANCE")
+                           : fTol;
+    CombineLogger::instance().log(
+        "CascadeMinimizer.cc",
+        __LINE__,
+        std::string(Form("Using minimizer %s with algorithm %s, strategy %d and tolerances f=%s g=%s p=%s",
+                         defaultMinimizerType_.c_str(),
+                         defaultMinimizerAlgo_.c_str(),
+                         strategy_,
+                         fTol.c_str(),
+                         gTol.c_str(),
+                         pTol.c_str())),
+        __func__);
+  } else {
+    CombineLogger::instance().log(
+        "CascadeMinimizer.cc",
+        __LINE__,
+        std::string(Form("Using minimizer %s with algorithm %s, strategy %d and tolerance %g",
+                         defaultMinimizerType_.c_str(),
+                         defaultMinimizerAlgo_.c_str(),
+                         strategy_,
+                         defaultMinimizerTolerance_)),
+        __func__);
   }
 
   //if (vm.count("cminDefaultIntegratorEpsAbs")) RooAbsReal::defaultIntegratorConfig()->setEpsAbs(vm["cminDefaultIntegratorEpsAbs"].as<double>());


### PR DESCRIPTION
## Summary
- Add numeric differentiation method selection for Ceres via `--cminCeresDiffMethod`
- Log function/gradient/parameter tolerances when using Ceres minimizer
- Fix `CeresMinimizer` name override for ROOT 6.30+

## Testing
- `make -C test/unit testCeresCovariance.exe` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d01c604483299b0d624d3f899974