### PR TITLE
Use double precision for minimizer settings

### DIFF
--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -68,9 +68,9 @@ class CascadeMinimizer {
         /// compact information about an algorithm
         struct Algo { 
             Algo() : type(), algo(), tolerance(), strategy(-1) {}
-            Algo(const std::string &tystr, const std::string &str, float tol=-1.f, int strategy=-1) :type(tystr), algo(str), tolerance(tol), strategy(strategy) {}
-            std::string type; std::string algo; float tolerance; int strategy;
-            static float default_tolerance() { return 0.1; }
+            Algo(const std::string &tystr, const std::string &str, double tol=-1., int strategy=-1) :type(tystr), algo(str), tolerance(tol), strategy(strategy) {}
+            std::string type; std::string algo; double tolerance; int strategy;
+            static double default_tolerance() { return 0.1; }
             static int   default_strategy() { return -1; }
         };
         /// list of algorithms to run if the default one fails
@@ -87,8 +87,8 @@ class CascadeMinimizer {
         static bool poiOnlyFit_;
         /// do first a minimization of each nuisance individually 
         static bool singleNuisFit_;
-        /// do first a minimization of each nuisance individually 
-        static float nuisancePruningThreshold_;
+        /// do first a minimization of each nuisance individually
+        static double nuisancePruningThreshold_;
         /// do first a fit of only the POI
         static bool setZeroPoint_;
         /// don't do old fallback using robustMinimize 

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -33,7 +33,7 @@ bool CascadeMinimizer::firstHesse_ = false;
 bool CascadeMinimizer::lastHesse_ = false;
 int CascadeMinimizer::minuit2StorageLevel_ = 0;
 bool CascadeMinimizer::runShortCombinations = true;
-float CascadeMinimizer::nuisancePruningThreshold_ = 0;
+double CascadeMinimizer::nuisancePruningThreshold_ = 0;
 double CascadeMinimizer::discreteMinTol_ = 0.001;
 std::string CascadeMinimizer::defaultMinimizerType_ = "Minuit2";  // default to minuit2 (not always the default !?)
 std::string CascadeMinimizer::defaultMinimizerAlgo_ = "Migrad";
@@ -108,7 +108,7 @@ bool CascadeMinimizer::improve(int verbose, bool cascade, bool forceResetMinimiz
   minimizer_->setStrategy(strategy_);
   std::string nominalType(ROOT::Math::MinimizerOptions::DefaultMinimizerType());
   std::string nominalAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
-  float nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
+  double nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
   minimizer_->setEps(nominalTol);
   if (approxPreFitTolerance_ > 0) {
     double tol = std::max(approxPreFitTolerance_, 10. * nominalTol);
@@ -343,7 +343,7 @@ bool CascadeMinimizer::hesse(int verbose) {
   if (simnllbb && !runtimedef::get(std::string("MINIMIZER_no_analytic"))) {
     // Have to reset and minimize again first to get all parameters in
     remakeMinimizer();
-    float nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
+    double nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
     minimizer_->setEps(nominalTol);
     minimizer_->setStrategy(strategy_);
     improveOnce(verbose - 1);
@@ -921,7 +921,7 @@ void CascadeMinimizer::initOptions() {
       "Symmetric relaxation applied to parameter bounds")("cminCeresAutoThreads",
                                                           boost::program_options::bool_switch()->default_value(false),
                                                           "Set Ceres threads to hardware concurrency when unspecified")
-      //("cminNuisancePruning", boost::program_options::value<float>(&nuisancePruningThreshold_)->default_value(nuisancePruningThreshold_), "if non-zero, discard constrained nuisances whose effect on the NLL when changing by 0.2*range is less than the absolute value of the threshold; if threshold is negative, repeat afterwards the fit with these floating")
+      //("cminNuisancePruning", boost::program_options::value<double>(&nuisancePruningThreshold_)->default_value(nuisancePruningThreshold_), "if non-zero, discard constrained nuisances whose effect on the NLL when changing by 0.2*range is less than the absolute value of the threshold; if threshold is negative, repeat afterwards the fit with these floating")
 
       //("cminDefaultIntegratorEpsAbs", boost::program_options::value<double>(), "RooAbsReal::defaultIntegratorConfig()->setEpsAbs(x)")
       //("cminDefaultIntegratorEpsRel", boost::program_options::value<double>(), "RooAbsReal::defaultIntegratorConfig()->setEpsRel(x)")
@@ -993,7 +993,7 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
     for (vector<string>::const_iterator it = falls.begin(), ed = falls.end(); it != ed; ++it) {
       std::string algo = *it;
       std::string type;
-      float tolerance = Algo::default_tolerance();
+      double tolerance = Algo::default_tolerance();
       int strategy = Algo::default_strategy();
       string::size_type idx = std::min(algo.find(';'), algo.find(':'));
       if (idx != string::npos && idx < algo.length()) {


### PR DESCRIPTION
## Summary
- promote cascade minimizer tolerances and pruning threshold to double precision
- adjust fallback algorithm configuration to use double values

## Testing
- `make -C test/unit` *(fails: `TFile.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4da377b488329acb45952537cfaa4