### PR TITLE
Use double precision for minimizer settings

### DIFF
--- a/interface/BayesianToyMC.h
+++ b/interface/BayesianToyMC.h
@@ -29,7 +29,7 @@ private:
   /// number of toy mc computations to run
   static unsigned int tries_;
   /// Safety factor for hint (integrate up to this number of times the hinted limit)
-  static float hintSafetyFactor_;
+  static double hintSafetyFactor_;
 
   static std::vector<std::string> twoPoints_;
   std::pair<double,double> priorPredictiveDistribution(RooStats::ModelConfig *mc, RooAbsData &data, const RooArgSet *point=0, double *offset=0);

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -68,9 +68,9 @@ class CascadeMinimizer {
         /// compact information about an algorithm
         struct Algo { 
             Algo() : type(), algo(), tolerance(), strategy(-1) {}
-            Algo(const std::string &tystr, const std::string &str, float tol=-1.f, int strategy=-1) :type(tystr), algo(str), tolerance(tol), strategy(strategy) {}
-            std::string type; std::string algo; float tolerance; int strategy;
-            static float default_tolerance() { return 0.1; }
+            Algo(const std::string &tystr, const std::string &str, double tol=-1., int strategy=-1) :type(tystr), algo(str), tolerance(tol), strategy(strategy) {}
+            std::string type; std::string algo; double tolerance; int strategy;
+            static double default_tolerance() { return 0.1; }
             static int   default_strategy() { return -1; }
         };
         /// list of algorithms to run if the default one fails
@@ -87,8 +87,8 @@ class CascadeMinimizer {
         static bool poiOnlyFit_;
         /// do first a minimization of each nuisance individually 
         static bool singleNuisFit_;
-        /// do first a minimization of each nuisance individually 
-        static float nuisancePruningThreshold_;
+        /// do first a minimization of each nuisance individually
+        static double nuisancePruningThreshold_;
         /// do first a fit of only the POI
         static bool setZeroPoint_;
         /// don't do old fallback using robustMinimize 

--- a/interface/ChannelCompatibilityCheck.h
+++ b/interface/ChannelCompatibilityCheck.h
@@ -22,7 +22,7 @@ public:
 protected:
   std::string nameForLabel(const char *label) ;
 
-  static float mu_;
+  static double mu_;
   static bool  fixedMu_;
 
   static bool runMinos_;

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -31,15 +31,15 @@ protected:
   //static std::string minimizerAlgo_, 
   static std::string minimizerAlgoForMinos_;
   //static float       minimizerTolerance_, 
-  static float 	     minimizerToleranceForMinos_;
-  static float 	     crossingTolerance_;
+  static double      minimizerToleranceForMinos_;
+  static double      crossingTolerance_;
   //static int         minimizerStrategy_, 
   static int 	     minimizerStrategyForMinos_;
 
-  static float preFitValue_;
+  static double preFitValue_;
 
   static bool robustFit_, do95_, forceRecreateNLL_;
-  static float stepSize_;
+  static double stepSize_;
   static int   maxFailedSteps_;
 
   enum ProfilingMode { ProfileAll, ProfileUnconstrained, ProfilePOI, NoProfiling };

--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -35,13 +35,13 @@ protected:
 //  static float       minimizerTolerance_;
 //  static int         minimizerStrategy_;
 
-  static float mu_;
+  static double mu_;
   static bool  fixedMu_;
 
   static bool  makePlots_;
   static TDirectory *plotDir_;
   static std::vector<std::string>  binNames_;
-  static std::vector<float>        qVals_;
+  static std::vector<double>       qVals_;
 
   static std::string setParametersForFit_;
   static std::string setParametersForEval_;

--- a/interface/HybridNew.h
+++ b/interface/HybridNew.h
@@ -51,7 +51,7 @@ private:
   static bool saveHybridResult_, readHybridResults_; 
   static std::string gridFile_;
   static bool expectedFromGrid_, clsQuantiles_; 
-  static float quantileForExpectedFromGrid_;
+    static double quantileForExpectedFromGrid_;
   static bool fullBToys_; 
   static bool fullGrid_; 
   static bool saveGrid_; 
@@ -69,11 +69,11 @@ private:
   static bool newToyMCSampler_;
   static bool rMinSet_;
   static bool rMaxSet_;
-  float mass_;
+  double mass_;
   static std::string	scaleAndConfidenceSelection_; 
-  static float maxProbability_;
-  static float confidenceToleranceForToyScaling_;
-  static float adaptiveToys_;
+  static double maxProbability_;
+  static double confidenceToleranceForToyScaling_;
+  static double adaptiveToys_;
 
   static double EPS;
   // graph, used to compute the limit, not just for plotting!

--- a/interface/JacknifeQuantile.h
+++ b/interface/JacknifeQuantile.h
@@ -19,14 +19,14 @@ class QuantileCalculator {
         void randomizePoints() ;
         std::pair<double,double> quantileAndError(double quantile, Method method);
     private:
-        struct point { 
-            float x, w; 
-            int set; 
+        struct point {
+            double x, w;
+            int set;
             inline bool operator<(const point &other) const { return x < other.x; }
         };
         std::vector<point> points_;
         std::vector<double> sumw_;
-        std::vector<float> quantiles_;
+        std::vector<double> quantiles_;
         std::mt19937 rng_{std::random_device{}()};
 
         int guessPartitions(int size, double quantile) ;

--- a/interface/MarkovChainMC.h
+++ b/interface/MarkovChainMC.h
@@ -32,17 +32,17 @@ private:
   /// Discard these points
   static unsigned int burnInSteps_;
   /// Discard these fraction of points
-  static float burnInFraction_;
+  static double burnInFraction_;
   /// Adaptive burn-in (experimental!)
   static bool adaptiveBurnIn_;
   /// compute the limit N times
   static unsigned int tries_;
   /// Ignore up to this fraction of results if they're too far from the median
-  static float truncatedMeanFraction_;
+  static double truncatedMeanFraction_;
   /// do adaptive truncated mean
   static bool adaptiveTruncation_;
   /// Safety factor for hint (integrate up to this number of times the hinted limit)
-  static float hintSafetyFactor_;
+  static double hintSafetyFactor_;
   /// Save Markov Chain in output file
   static bool saveChain_;
   /// Leave all parameters in the markov chain, not just the POI 
@@ -52,15 +52,15 @@ private:
   /// Read chains from file instead of running them 
   static bool readChains_;
   /// Mass of the Higgs boson (goes into the name of the saved chains)
-  float mass_;
+  double mass_;
   /// Number of degrees of freedom of the problem, approximately
   int   modelNDF_;
 
   static unsigned int numberOfBins_;
   static unsigned int proposalHelperCacheSize_;
   static bool         alwaysStepPoi_;
-  static float        proposalHelperWidthRangeDivisor_, proposalHelperUniformFraction_;
-  static float        cropNSigmas_;
+  static double       proposalHelperWidthRangeDivisor_, proposalHelperUniformFraction_;
+  static double       cropNSigmas_;
   static int          debugProposal_;
   ///
   static std::vector<std::string> discreteModelPoints_;

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -35,10 +35,10 @@ protected:
 
   static std::vector<std::string>  poi_;
   static std::vector<RooRealVar*>  poiVars_;
-  static std::vector<float>        poiVals_;
-  static RooArgList                poiList_; 
+  static std::vector<double>       poiVals_;
+  static RooArgList                poiList_;
   static unsigned int              nOtherFloatingPoi_; // keep a count of other POIs that we're ignoring, for proper chisquare normalization
-  static float                     deltaNLL_;
+  static double                    deltaNLL_;
 
   static std::string name_;
   static std::string massName_;
@@ -55,13 +55,13 @@ protected:
   static bool fastScan_;
   static bool hasMaxDeltaNLLForProf_;
   static bool loadedSnapshot_,  savingSnapshot_;
-  static float maxDeltaNLLForProf_;
-  static float autoRange_;
+  static double maxDeltaNLLForProf_;
+  static double autoRange_;
   static bool  startFromPreFit_;
   static bool  alignEdges_;
   static bool  saveFitResult_;
   static std::string fixedPointPOIs_;
-  static float centeredRange_;
+  static double centeredRange_;
   static std::string setParametersForGrid_;
 
   static bool robustHesse_;
@@ -77,7 +77,7 @@ protected:
   static std::string saveSpecifiedIndex_;
   static std::vector<std::string>  specifiedFuncNames_;
   static std::vector<RooAbsReal*> specifiedFunc_;
-  static std::vector<float>        specifiedFuncVals_;
+  static std::vector<double>       specifiedFuncVals_;
   static RooArgList                specifiedFuncList_;
   static std::vector<std::string>  specifiedCatNames_;
   static std::vector<RooCategory*> specifiedCat_;
@@ -85,7 +85,7 @@ protected:
   static RooArgList                specifiedCatList_;
   static std::vector<std::string>  specifiedNuis_;
   static std::vector<RooRealVar *> specifiedVars_;
-  static std::vector<float>        specifiedVals_;
+  static std::vector<double>       specifiedVals_;
   static RooArgList                specifiedList_;
   static bool saveInactivePOI_;
   static bool skipDefaultStart_;
@@ -101,7 +101,7 @@ protected:
   void doStitch2D(RooWorkspace *w, RooAbsReal &nll) ;
   void doImpact(RooFitResult &res, RooAbsReal &nll) ;
 
-  std::map<std::string, std::vector<float>> getRangesDictFromInString(std::string) ;
+  std::map<std::string, std::vector<double>> getRangesDictFromInString(std::string) ;
 
 
   // utilities

--- a/interface/RandStartPt.h
+++ b/interface/RandStartPt.h
@@ -15,31 +15,31 @@ class RandStartPt {
   private:
       RooAbsReal& nll_;
       std::vector<RooRealVar* > &specifiedvars_;
-      std::vector<float> &specifiedvals_;
+      std::vector<double> &specifiedvals_;
       bool skipdefaultstart_;
       std::string parameterRandInitialValranges_;
       int numrandpts_;
       int verbosity_;
       bool fastscan_;
       bool hasmaxdeltaNLLforprof_;
-      float maxdeltaNLLforprof_;
+      double maxdeltaNLLforprof_;
       std::vector<std::string> &specifiednuis_;
       std::vector<std::string> &specifiedfuncnames_;
       std::vector<RooAbsReal*> &specifiedfunc_;
-      std::vector<float> &specifiedfuncvals_; 
+      std::vector<double> &specifiedfuncvals_;
       std::vector<std::string> &specifiedcatnames_; 
       std::vector<RooCategory*> &specifiedcat_; 
       std::vector<int> &specifiedcatvals_;
       unsigned int nOtherFloatingPOI_;
   public:
-      RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<float> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, float maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<float> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI);
-      std::map<std::string, std::vector<float>> getRangesDictFromInString(std::string params_ranges_string_in);
-      std::vector<std::vector<float>> vectorOfPointsToTry ();
-      void commitBestNLLVal(unsigned int idx, float &nllVal, double &probVal);
-      void setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<float>> &nested_vector_of_wc_vals);
+      RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<double> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, double maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<double> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI);
+      std::map<std::string, std::vector<double>> getRangesDictFromInString(std::string params_ranges_string_in);
+      std::vector<std::vector<double>> vectorOfPointsToTry ();
+      void commitBestNLLVal(unsigned int idx, double &nllVal, double &probVal);
+      void setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<double>> &nested_vector_of_wc_vals);
       void setValSpecifiedObjs();
-      void doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, float &deltaNLL, double &nll_init, CascadeMinimizer &minimObj);
-      void doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, float &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj);
+      void doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, CascadeMinimizer &minimObj);
+      void doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj);
 
 };
 #endif

--- a/interface/Significance.h
+++ b/interface/Significance.h
@@ -36,7 +36,7 @@ protected:
   //static std::string minimizerAlgo_, 
   static std::string minimizerAlgoForBF_;
   //static float       minimizerTolerance_, 
-  static float minimizerToleranceForBF_;
+  static double minimizerToleranceForBF_;
 
   static bool useMinos_, bruteForce_;
   static std::string bfAlgo_;
@@ -48,9 +48,9 @@ protected:
   /// trying up to M times from different points
   static int         maxTries_;
   /// maximum relative deviation of the different points from the median to accept 
-  static float       maxRelDeviation_;
+  static double      maxRelDeviation_;
   /// Ignore up to this fraction of results if they're too far from the median
-  static float       maxOutlierFraction_;
+  static double      maxOutlierFraction_;
   /// Stop trying after finding N outliers
   static int         maxOutliers_;
   /// Try first a plain fit
@@ -60,8 +60,8 @@ protected:
   static bool reportPVal_;
   static bool uncapped_;
 
-  static float signalForSignificance_;
-  static float mass_;
+  static double signalForSignificance_;
+  static double mass_;
 
   static std::string plot_;
 

--- a/src/BayesianToyMC.cc
+++ b/src/BayesianToyMC.cc
@@ -22,7 +22,7 @@ using namespace RooStats;
 int BayesianToyMC::numIters_ = 1000;
 std::string BayesianToyMC::integrationType_ = "toymc";
 unsigned int BayesianToyMC::tries_ = 1;
-float BayesianToyMC::hintSafetyFactor_ = 5.;
+double BayesianToyMC::hintSafetyFactor_ = 5.;
 std::vector<std::string> BayesianToyMC::twoPoints_;
 
 BayesianToyMC::BayesianToyMC() :
@@ -33,7 +33,7 @@ BayesianToyMC::BayesianToyMC() :
         ("tries",      boost::program_options::value<unsigned int>(&tries_)->default_value(tries_), "Number of times to run the ToyMC on the same data")
         ("numIters,i", boost::program_options::value<int>(&numIters_)->default_value(numIters_),    "Number of iterations or calls used within iteration (0=ROOT Default)")
         ("hintSafetyFactor",
-                boost::program_options::value<float>(&hintSafetyFactor_)->default_value(hintSafetyFactor_),
+                boost::program_options::value<double>(&hintSafetyFactor_)->default_value(hintSafetyFactor_),
                 "Set range of integration equal to this number of times the hinted limit")
         ("twoPoints",
                 boost::program_options::value<std::vector<std::string> >(&twoPoints_)->multitoken(), "Compute BF comparing two points in parameter space");

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -33,7 +33,7 @@ bool CascadeMinimizer::firstHesse_ = false;
 bool CascadeMinimizer::lastHesse_ = false;
 int CascadeMinimizer::minuit2StorageLevel_ = 0;
 bool CascadeMinimizer::runShortCombinations = true;
-float CascadeMinimizer::nuisancePruningThreshold_ = 0;
+double CascadeMinimizer::nuisancePruningThreshold_ = 0;
 double CascadeMinimizer::discreteMinTol_ = 0.001;
 std::string CascadeMinimizer::defaultMinimizerType_ = "Minuit2";  // default to minuit2 (not always the default !?)
 std::string CascadeMinimizer::defaultMinimizerAlgo_ = "Migrad";
@@ -108,7 +108,7 @@ bool CascadeMinimizer::improve(int verbose, bool cascade, bool forceResetMinimiz
   minimizer_->setStrategy(strategy_);
   std::string nominalType(ROOT::Math::MinimizerOptions::DefaultMinimizerType());
   std::string nominalAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
-  float nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
+  double nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
   minimizer_->setEps(nominalTol);
   if (approxPreFitTolerance_ > 0) {
     double tol = std::max(approxPreFitTolerance_, 10. * nominalTol);
@@ -343,7 +343,7 @@ bool CascadeMinimizer::hesse(int verbose) {
   if (simnllbb && !runtimedef::get(std::string("MINIMIZER_no_analytic"))) {
     // Have to reset and minimize again first to get all parameters in
     remakeMinimizer();
-    float nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
+    double nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
     minimizer_->setEps(nominalTol);
     minimizer_->setStrategy(strategy_);
     improveOnce(verbose - 1);
@@ -921,7 +921,7 @@ void CascadeMinimizer::initOptions() {
       "Symmetric relaxation applied to parameter bounds")("cminCeresAutoThreads",
                                                           boost::program_options::bool_switch()->default_value(false),
                                                           "Set Ceres threads to hardware concurrency when unspecified")
-      //("cminNuisancePruning", boost::program_options::value<float>(&nuisancePruningThreshold_)->default_value(nuisancePruningThreshold_), "if non-zero, discard constrained nuisances whose effect on the NLL when changing by 0.2*range is less than the absolute value of the threshold; if threshold is negative, repeat afterwards the fit with these floating")
+      //("cminNuisancePruning", boost::program_options::value<double>(&nuisancePruningThreshold_)->default_value(nuisancePruningThreshold_), "if non-zero, discard constrained nuisances whose effect on the NLL when changing by 0.2*range is less than the absolute value of the threshold; if threshold is negative, repeat afterwards the fit with these floating")
 
       //("cminDefaultIntegratorEpsAbs", boost::program_options::value<double>(), "RooAbsReal::defaultIntegratorConfig()->setEpsAbs(x)")
       //("cminDefaultIntegratorEpsRel", boost::program_options::value<double>(), "RooAbsReal::defaultIntegratorConfig()->setEpsRel(x)")
@@ -993,7 +993,7 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
     for (vector<string>::const_iterator it = falls.begin(), ed = falls.end(); it != ed; ++it) {
       std::string algo = *it;
       std::string type;
-      float tolerance = Algo::default_tolerance();
+      double tolerance = Algo::default_tolerance();
       int strategy = Algo::default_strategy();
       string::size_type idx = std::min(algo.find(';'), algo.find(':'));
       if (idx != string::npos && idx < algo.length()) {

--- a/src/ChannelCompatibilityCheck.cc
+++ b/src/ChannelCompatibilityCheck.cc
@@ -20,7 +20,7 @@
 
 using namespace RooStats;
 
-float ChannelCompatibilityCheck::mu_ = 0.0;
+double ChannelCompatibilityCheck::mu_ = 0.0;
 bool  ChannelCompatibilityCheck::fixedMu_ = false;
 bool  ChannelCompatibilityCheck::saveFitResult_ = true;
 bool  ChannelCompatibilityCheck::runMinos_ = true;
@@ -31,7 +31,7 @@ ChannelCompatibilityCheck::ChannelCompatibilityCheck() :
     FitterAlgoBase("ChannelCompatibilityCheck specific options")
 {
     options_.add_options()
-        ("fixedSignalStrength", boost::program_options::value<float>(&mu_)->default_value(mu_),  "Compute the compatibility for a fixed signal strength. If not specified, it is left floating")
+        ("fixedSignalStrength", boost::program_options::value<double>(&mu_)->default_value(mu_),  "Compute the compatibility for a fixed signal strength. If not specified, it is left floating")
         ("saveFitResult",       "Save fit results in output file")
         ("group,g",             boost::program_options::value<std::vector<std::string> >(&groups_), "Group together channels that contain a given name. Can be used multiple times. Optionally, set range as name=rMin,rMax")
         ("runMinos", boost::program_options::value<bool>(&runMinos_)->default_value(runMinos_), "Also compute uncertainties using profile likeilhood (MINOS or robust variants of it)")

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -44,12 +44,12 @@ using namespace RooStats;
 //std::string FitterAlgoBase::minimizerAlgo_ = "Minuit2";
 std::string FitterAlgoBase::minimizerAlgoForMinos_ = "";
 //float       FitterAlgoBase::minimizerTolerance_ = 1e-1;
-float FitterAlgoBase::minimizerToleranceForMinos_ = 1e-1;
-float FitterAlgoBase::crossingTolerance_ = 1e-4;
+double FitterAlgoBase::minimizerToleranceForMinos_ = 1e-1;
+double FitterAlgoBase::crossingTolerance_ = 1e-4;
 //int         FitterAlgoBase::minimizerStrategy_  = 1;
 int FitterAlgoBase::minimizerStrategyForMinos_ = 0;  // also default from CascadeMinimizer
-float FitterAlgoBase::preFitValue_ = 1.0;
-float FitterAlgoBase::stepSize_ = 0.1;
+double FitterAlgoBase::preFitValue_ = 1.0;
+double FitterAlgoBase::stepSize_ = 0.1;
 bool FitterAlgoBase::robustFit_ = false;
 int FitterAlgoBase::maxFailedSteps_ = 5;
 bool FitterAlgoBase::do95_ = false;
@@ -69,7 +69,7 @@ FitterAlgoBase::FitterAlgoBase(const char *title) : LimitAlgo(title) {
       //("minimizerTolerance", boost::program_options::value<float>(&minimizerTolerance_)->default_value(minimizerTolerance_),  "Tolerance for minimizer")
       //("minimizerStrategy",  boost::program_options::value<int>(&minimizerStrategy_)->default_value(minimizerStrategy_),      "Stragegy for minimizer")
       ("preFitValue",
-       boost::program_options::value<float>(&preFitValue_)->default_value(preFitValue_),
+       boost::program_options::value<double>(&preFitValue_)->default_value(preFitValue_),
        "Value of signal strength pre-fit, also used for pre-fit plots, normalizations and uncertainty calculations "
        "(note this overrides --expectSignal for these features)")(
           "do95",
@@ -82,7 +82,7 @@ FitterAlgoBase::FitterAlgoBase(const char *title) : LimitAlgo(title) {
           boost::program_options::value<int>(&maxFailedSteps_)->default_value(maxFailedSteps_),
           "How many failed steps to retry before giving up")(
           "stepSize",
-          boost::program_options::value<float>(&stepSize_)->default_value(stepSize_),
+          boost::program_options::value<double>(&stepSize_)->default_value(stepSize_),
           "Step size for robust fits (multiplier of the range)")(
           "setRobustFitAlgo",
           boost::program_options::value<std::string>(&minimizerAlgoForMinos_)->default_value(minimizerAlgoForMinos_),
@@ -91,10 +91,10 @@ FitterAlgoBase::FitterAlgoBase(const char *title) : LimitAlgo(title) {
           boost::program_options::value<int>(&minimizerStrategyForMinos_)->default_value(minimizerStrategyForMinos_),
           "Stragegy for minimizer for profiling in robust fits")(
           "setRobustFitTolerance",
-          boost::program_options::value<float>(&minimizerToleranceForMinos_)->default_value(minimizerToleranceForMinos_),
+          boost::program_options::value<double>(&minimizerToleranceForMinos_)->default_value(minimizerToleranceForMinos_),
           "Tolerance for minimizer for profiling in robust fits")(
           "setCrossingTolerance",
-          boost::program_options::value<float>(&crossingTolerance_)->default_value(crossingTolerance_),
+          boost::program_options::value<double>(&crossingTolerance_)->default_value(crossingTolerance_),
           "Tolerance for finding the NLL crossing in robust fits")(
           "profilingMode",
           boost::program_options::value<std::string>()->default_value("all"),

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -39,12 +39,12 @@ std::string GoodnessOfFit::algo_;
 //std::string GoodnessOfFit::minimizerAlgo_ = "Minuit2";
 //float       GoodnessOfFit::minimizerTolerance_ = 1e-4;
 //int         GoodnessOfFit::minimizerStrategy_  = 1;
-float       GoodnessOfFit::mu_ = 0.0;
+double      GoodnessOfFit::mu_ = 0.0;
 bool        GoodnessOfFit::fixedMu_ = false;
 bool        GoodnessOfFit::makePlots_ = false;
 TDirectory* GoodnessOfFit::plotDir_ = nullptr;
 std::vector<std::string>  GoodnessOfFit::binNames_;
-std::vector<float>        GoodnessOfFit::qVals_;
+std::vector<double>       GoodnessOfFit::qVals_;
 std::string GoodnessOfFit::setParametersForFit_ = "";
 std::string GoodnessOfFit::setParametersForEval_ = "";
 
@@ -58,7 +58,7 @@ GoodnessOfFit::GoodnessOfFit() :
   //      ("minimizerAlgo",      boost::program_options::value<std::string>(&minimizerAlgo_)->default_value(minimizerAlgo_), "Choice of minimizer (Minuit vs Minuit2)")
   //      ("minimizerTolerance", boost::program_options::value<float>(&minimizerTolerance_)->default_value(minimizerTolerance_),  "Tolerance for minimizer")
   //      ("minimizerStrategy",  boost::program_options::value<int>(&minimizerStrategy_)->default_value(minimizerStrategy_),      "Stragegy for minimizer")
-        ("fixedSignalStrength", boost::program_options::value<float>(&mu_)->default_value(mu_),  "Compute the goodness of fit for a fixed signal strength. If not specified, it is left floating")
+        ("fixedSignalStrength", boost::program_options::value<double>(&mu_)->default_value(mu_),  "Compute the goodness of fit for a fixed signal strength. If not specified, it is left floating")
         ("plots",  "Make plots containing information of the computation of the Anderson-Darling or Kolmogorov-Smirnov test statistic")
     ;
 }
@@ -114,7 +114,7 @@ void GoodnessOfFit::initKSandAD(RooStats::ModelConfig *mc_s) {
       cat->setBin(i);
       binNames_[i] = cat->getLabel();
       qVals_[i] = 0.;
-      Combine::addBranch(binNames_[i].c_str(), &qVals_[i], (binNames_[i]+"/F").c_str());
+      Combine::addBranch(binNames_[i].c_str(), &qVals_[i], (binNames_[i]+"/D").c_str());
     }
   }
 }

--- a/src/MarkovChainMC.cc
+++ b/src/MarkovChainMC.cc
@@ -39,20 +39,20 @@ bool MarkovChainMC::updateProposalParams_ = false;
 bool MarkovChainMC::updateHint_ = false;
 unsigned int MarkovChainMC::iterations_ = 10000;
 unsigned int MarkovChainMC::burnInSteps_ = 200;
-float MarkovChainMC::burnInFraction_ = 0.25;
+double MarkovChainMC::burnInFraction_ = 0.25;
 bool  MarkovChainMC::adaptiveBurnIn_ = false;
 unsigned int MarkovChainMC::tries_ = 10;
-float MarkovChainMC::truncatedMeanFraction_ = 0.0;
+double MarkovChainMC::truncatedMeanFraction_ = 0.0;
 bool MarkovChainMC::adaptiveTruncation_ = true;
-float MarkovChainMC::hintSafetyFactor_ = 5.;
+double MarkovChainMC::hintSafetyFactor_ = 5.;
 bool MarkovChainMC::saveChain_ = false;
 bool MarkovChainMC::noSlimChain_ = false;
 bool MarkovChainMC::mergeChains_ = false;
 bool MarkovChainMC::readChains_ = false;
-float MarkovChainMC::proposalHelperWidthRangeDivisor_ = 5.;
-float MarkovChainMC::proposalHelperUniformFraction_ = 0.0;
+double MarkovChainMC::proposalHelperWidthRangeDivisor_ = 5.;
+double MarkovChainMC::proposalHelperUniformFraction_ = 0.0;
 bool  MarkovChainMC::alwaysStepPoi_ = true;
-float MarkovChainMC::cropNSigmas_ = 0;
+double MarkovChainMC::cropNSigmas_ = 0;
 int   MarkovChainMC::debugProposal_ = false;
 std::vector<std::string> MarkovChainMC::discreteModelPoints_;
 
@@ -63,7 +63,7 @@ MarkovChainMC::MarkovChainMC() :
         ("iteration,i", boost::program_options::value<unsigned int>(&iterations_)->default_value(iterations_), "Number of iterations")
         ("tries", boost::program_options::value<unsigned int>(&tries_)->default_value(tries_), "Number of times to run the MCMC on the same data")
         ("burnInSteps,b", boost::program_options::value<unsigned int>(&burnInSteps_)->default_value(burnInSteps_), "Burn in steps (absolute number)")
-        ("burnInFraction", boost::program_options::value<float>(&burnInFraction_)->default_value(burnInFraction_), "Burn in steps (fraction of total accepted steps)")
+        ("burnInFraction", boost::program_options::value<double>(&burnInFraction_)->default_value(burnInFraction_), "Burn in steps (fraction of total accepted steps)")
         ("adaptiveBurnIn", boost::program_options::value<bool>(&adaptiveBurnIn_)->default_value(adaptiveBurnIn_), "Adaptively determine burn in steps (experimental!).")
         ("proposal", boost::program_options::value<std::string>(&proposalTypeName_)->default_value(proposalTypeName_), 
                               "Proposal function to use: 'fit', 'uniform', 'gaus', 'ortho' (also known as 'test')")
@@ -74,24 +74,24 @@ MarkovChainMC::MarkovChainMC() :
                 boost::program_options::value<bool>(&updateProposalParams_)->default_value(updateProposalParams_), 
                 "Control ProposalHelper::SetUpdateProposalParameters")
         ("propHelperWidthRangeDivisor", 
-                boost::program_options::value<float>(&proposalHelperWidthRangeDivisor_)->default_value(proposalHelperWidthRangeDivisor_), 
+                boost::program_options::value<double>(&proposalHelperWidthRangeDivisor_)->default_value(proposalHelperWidthRangeDivisor_),
                 "Sets the fractional size of the gaussians in the proposal")
         ("alwaysStepPOI", boost::program_options::value<bool>(&alwaysStepPoi_)->default_value(alwaysStepPoi_),
                             "When using 'ortho' proposal, always step also the parameter of interest. On by default, as it improves convergence, but you can turn it off (e.g. if you turn off --optimizeSimPdf)")
         ("propHelperUniformFraction", 
-                boost::program_options::value<float>(&proposalHelperUniformFraction_)->default_value(proposalHelperUniformFraction_), 
+                boost::program_options::value<double>(&proposalHelperUniformFraction_)->default_value(proposalHelperUniformFraction_),
                 "Add a fraction of uniform proposals to the algorithm")
         ("debugProposal", boost::program_options::value<int>(&debugProposal_)->default_value(debugProposal_), "Printout the first N proposals")
         ("cropNSigmas", 
-                boost::program_options::value<float>(&cropNSigmas_)->default_value(cropNSigmas_),
+                boost::program_options::value<double>(&cropNSigmas_)->default_value(cropNSigmas_),
                 "crop range of all parameters to N times their uncertainty") 
         ("truncatedMeanFraction", 
-                boost::program_options::value<float>(&truncatedMeanFraction_)->default_value(truncatedMeanFraction_), 
+                boost::program_options::value<double>(&truncatedMeanFraction_)->default_value(truncatedMeanFraction_),
                 "Discard this fraction of the results before computing the mean and rms")
         ("adaptiveTruncation", boost::program_options::value<bool>(&adaptiveTruncation_)->default_value(adaptiveTruncation_),
                             "When averaging multiple runs, ignore results that are more far away from the median than the inter-quartile range")
         ("hintSafetyFactor",
-                boost::program_options::value<float>(&hintSafetyFactor_)->default_value(hintSafetyFactor_),
+                boost::program_options::value<double>(&hintSafetyFactor_)->default_value(hintSafetyFactor_),
                 "set range of integration equal to this number of times the hinted limit")
         ("saveChain", "Save MarkovChain to output file")
         ("noSlimChain", "Include also nuisance parameters in the chain that is saved to file")
@@ -118,7 +118,7 @@ void MarkovChainMC::applyOptions(const boost::program_options::variables_map &vm
     noReset_  = vm.count("noReset");
     updateHint_  = vm.count("updateHint");
 
-    mass_ = vm["mass"].as<float>();
+    mass_ = vm["mass"].as<double>();
     saveChain_   = vm.count("saveChain");
     noSlimChain_   = vm.count("noSlimChain");
     mergeChains_ = vm.count("mergeChains");

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -36,9 +36,9 @@ MultiDimFit::Algo MultiDimFit::algo_ = None;
 MultiDimFit::GridType MultiDimFit::gridType_ = G1x1;
 std::vector<std::string>  MultiDimFit::poi_;
 std::vector<RooRealVar *> MultiDimFit::poiVars_;
-std::vector<float>        MultiDimFit::poiVals_;
+std::vector<double>       MultiDimFit::poiVals_;
 RooArgList                MultiDimFit::poiList_;
-float                     MultiDimFit::deltaNLL_ = 0;
+double                    MultiDimFit::deltaNLL_ = 0;
 unsigned int MultiDimFit::points_ = 50;
 unsigned int MultiDimFit::firstPoint_ = 0;
 unsigned int MultiDimFit::lastPoint_  = std::numeric_limits<unsigned int>::max();
@@ -54,10 +54,10 @@ bool MultiDimFit::hasMaxDeltaNLLForProf_ = false;
 bool MultiDimFit::squareDistPoiStep_ = false;
 bool MultiDimFit::skipInitialFit_ = false;
 bool MultiDimFit::saveFitResult_ = false;
-float MultiDimFit::maxDeltaNLLForProf_ = 200;
-float MultiDimFit::autoRange_ = -1.0;
+double MultiDimFit::maxDeltaNLLForProf_ = 200;
+double MultiDimFit::autoRange_ = -1.0;
 std::string MultiDimFit::fixedPointPOIs_ = "";
-float MultiDimFit::centeredRange_ = -1.0;
+double MultiDimFit::centeredRange_ = -1.0;
 bool        MultiDimFit::robustHesse_ = false;
 std::string MultiDimFit::robustHesseLoad_ = "";
 std::string MultiDimFit::robustHesseSave_ = "";
@@ -72,7 +72,7 @@ std::string MultiDimFit::saveSpecifiedNuis_;
 std::string MultiDimFit::setParametersForGrid_;
 std::vector<std::string>  MultiDimFit::specifiedFuncNames_;
 std::vector<RooAbsReal*> MultiDimFit::specifiedFunc_;
-std::vector<float>        MultiDimFit::specifiedFuncVals_;
+std::vector<double>       MultiDimFit::specifiedFuncVals_;
 RooArgList                MultiDimFit::specifiedFuncList_;
 std::vector<std::string>  MultiDimFit::specifiedCatNames_;
 std::vector<RooCategory*> MultiDimFit::specifiedCat_;
@@ -80,7 +80,7 @@ std::vector<int>        MultiDimFit::specifiedCatVals_;
 RooArgList                MultiDimFit::specifiedCatList_;
 std::vector<std::string>  MultiDimFit::specifiedNuis_;
 std::vector<RooRealVar *> MultiDimFit::specifiedVars_;
-std::vector<float>        MultiDimFit::specifiedVals_;
+std::vector<double>       MultiDimFit::specifiedVals_;
 RooArgList                MultiDimFit::specifiedList_;
 bool MultiDimFit::saveInactivePOI_= false;
 bool MultiDimFit::skipDefaultStart_ = false;
@@ -98,11 +98,11 @@ MultiDimFit::MultiDimFit() :
         ("gridPoints",  boost::program_options::value<std::string>(&gridPoints_)->default_value(gridPoints_), "Comma separated list of points per POI for multidimensional grid scans. When set, --points is ignored.")
         ("firstPoint",  boost::program_options::value<unsigned int>(&firstPoint_)->default_value(firstPoint_), "First point to use")
         ("lastPoint",  boost::program_options::value<unsigned int>(&lastPoint_)->default_value(lastPoint_), "Last point to use")
-        ("autoRange", boost::program_options::value<float>(&autoRange_)->default_value(autoRange_), "Set to any X >= 0 to do the scan in the +/- X sigma range (where the sigma is from the initial fit, so it may be fairly approximate)")
+        ("autoRange", boost::program_options::value<double>(&autoRange_)->default_value(autoRange_), "Set to any X >= 0 to do the scan in the +/- X sigma range (where the sigma is from the initial fit, so it may be fairly approximate)")
 	("fixedPointPOIs",   boost::program_options::value<std::string>(&fixedPointPOIs_)->default_value(""), "Parameter space point for --algo=fixed")
-        ("centeredRange", boost::program_options::value<float>(&centeredRange_)->default_value(centeredRange_), "Set to any X >= 0 to do the scan in the +/- X range centered on the nominal value")
+        ("centeredRange", boost::program_options::value<double>(&centeredRange_)->default_value(centeredRange_), "Set to any X >= 0 to do the scan in the +/- X range centered on the nominal value")
         ("fastScan", "Do a fast scan, evaluating the likelihood without profiling it.")
-        ("maxDeltaNLLForProf",  boost::program_options::value<float>(&maxDeltaNLLForProf_)->default_value(maxDeltaNLLForProf_), "Last point to use")
+        ("maxDeltaNLLForProf",  boost::program_options::value<double>(&maxDeltaNLLForProf_)->default_value(maxDeltaNLLForProf_), "Last point to use")
 	("saveSpecifiedNuis",   boost::program_options::value<std::string>(&saveSpecifiedNuis_)->default_value(""), "Save specified parameters (default = none)")
 	("saveSpecifiedFunc",   boost::program_options::value<std::string>(&saveSpecifiedFuncs_)->default_value(""), "Save specified function values (default = none)")
 	("saveSpecifiedIndex",   boost::program_options::value<std::string>(&saveSpecifiedIndex_)->default_value(""), "Save specified indexes/discretes (default = none)")
@@ -430,18 +430,18 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 
     // then add the branches to the tree (at the end, so there are no resizes)
     for (int i = 0, n = poi_.size(); i < n; ++i) {
-        Combine::addBranch(poi_[i].c_str(), &poiVals_[i], (poi_[i]+"/F").c_str()); 
+        Combine::addBranch(poi_[i].c_str(), &poiVals_[i], (poi_[i]+"/D").c_str());
     }
     for (int i = 0, n = specifiedNuis_.size(); i < n; ++i) {
-	Combine::addBranch(specifiedNuis_[i].c_str(), &specifiedVals_[i], (specifiedNuis_[i]+"/F").c_str()); 
+        Combine::addBranch(specifiedNuis_[i].c_str(), &specifiedVals_[i], (specifiedNuis_[i]+"/D").c_str());
     }
     for (int i = 0, n = specifiedFuncNames_.size(); i < n; ++i) {
-	Combine::addBranch(specifiedFuncNames_[i].c_str(), &specifiedFuncVals_[i], (specifiedFuncNames_[i]+"/F").c_str()); 
+        Combine::addBranch(specifiedFuncNames_[i].c_str(), &specifiedFuncVals_[i], (specifiedFuncNames_[i]+"/D").c_str());
     }
     for (int i = 0, n = specifiedCatNames_.size(); i < n; ++i) {
 	Combine::addBranch(specifiedCatNames_[i].c_str(), &specifiedCatVals_[i], (specifiedCatNames_[i]+"/I").c_str()); 
     }
-    Combine::addBranch("deltaNLL", &deltaNLL_, "deltaNLL/F");
+    Combine::addBranch("deltaNLL", &deltaNLL_, "deltaNLL/D");
 }
 
 void MultiDimFit::doSingles(RooFitResult &res)
@@ -514,9 +514,9 @@ void MultiDimFit::doImpact(RooFitResult &res, RooAbsReal &nll) {
 
   // Save the best-fit values of the saved parameters
   // we want to measure the impacts on
-  std::vector<float> specifiedVals = specifiedVals_;
-  std::vector<float> impactLo = specifiedVals_;
-  std::vector<float> impactHi = specifiedVals_;
+  std::vector<double> specifiedVals = specifiedVals_;
+  std::vector<double> impactLo = specifiedVals_;
+  std::vector<double> impactHi = specifiedVals_;
 
   int len = 9;
   for (int i = 0, n = poi_.size(); i < n; ++i) {
@@ -1021,8 +1021,8 @@ void MultiDimFit::doFixedPoint(RooWorkspace *w, RooAbsReal &nll)
 void MultiDimFit::doContour2D(RooWorkspace *, RooAbsReal &nll) 
 {
     if (poi_.size() != 2) throw std::logic_error("Contour2D works only in 2 dimensions");
-    RooRealVar *xv = poiVars_[0]; double x0 = poiVals_[0]; float &x = poiVals_[0];
-    RooRealVar *yv = poiVars_[1]; double y0 = poiVals_[1]; float &y = poiVals_[1];
+    RooRealVar *xv = poiVars_[0]; double x0 = poiVals_[0]; double &x = poiVals_[0];
+    RooRealVar *yv = poiVars_[1]; double y0 = poiVals_[1]; double &y = poiVals_[1];
 
     double threshold = nll.getVal() + 0.5*ROOT::Math::chisquared_quantile_c(1-cl,2+nOtherFloatingPoi_);
     if (verbose>0) CombineLogger::instance().log("MultiDimFit.cc",__LINE__,std::string(Form("Best fit point is for %s, %s, = %.4f,%.4f",xv->GetName(),yv->GetName(),x0,y0)),__func__);
@@ -1205,8 +1205,8 @@ void MultiDimFit::splitGridPoints(const std::string& s, std::vector<unsigned int
 
 // Extract the ranges map from the input string
 // Assumes the string is formatted with colons like "poi_name1=lo_lim,hi_lim:poi_name2=lo_lim,hi_lim"
-std::map<std::string, std::vector<float>> MultiDimFit::getRangesDictFromInString(std::string params_ranges_string_in) {
-    std::map<std::string, std::vector<float>> out_range_dict;
+std::map<std::string, std::vector<double>> MultiDimFit::getRangesDictFromInString(std::string params_ranges_string_in) {
+    std::map<std::string, std::vector<double>> out_range_dict;
     std::vector<std::string> params_ranges_string_lst = Utils::split(params_ranges_string_in, ":");
     for (UInt_t p = 0; p < params_ranges_string_lst.size(); ++p) {
         std::vector<std::string> params_ranges_string = Utils::split(params_ranges_string_lst[p], "=,");
@@ -1214,8 +1214,8 @@ std::map<std::string, std::vector<float>> MultiDimFit::getRangesDictFromInString
             std::cout << "Error parsing expression : " << params_ranges_string_lst[p] << std::endl;
         }
         std::string wc_name =params_ranges_string[0];
-        float lim_lo = atof(params_ranges_string[1].c_str());
-        float lim_hi = atof(params_ranges_string[2].c_str());
+        double lim_lo = atof(params_ranges_string[1].c_str());
+        double lim_hi = atof(params_ranges_string[2].c_str());
         out_range_dict.insert({wc_name,{lim_lo,lim_hi}});
     }
     return out_range_dict;

--- a/src/RandStartPt.cc
+++ b/src/RandStartPt.cc
@@ -19,7 +19,7 @@
 #include <Math/QuantFuncMathCore.h>
 #include <Math/ProbFunc.h>
 
-RandStartPt::RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<float> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, float maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<float> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI) :
+RandStartPt::RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<double> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, double maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<double> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI) :
     nll_(nll),
     specifiedvars_(specifiedvars),
     specifiedvals_(specifiedvals),
@@ -41,12 +41,12 @@ RandStartPt::RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedva
 
     {}
 
-std::vector<std::vector<float>> RandStartPt::vectorOfPointsToTry (){
-    std::vector<std::vector<float>> wc_vals_vec_of_vec = {};
+std::vector<std::vector<double>> RandStartPt::vectorOfPointsToTry (){
+    std::vector<std::vector<double>> wc_vals_vec_of_vec = {};
     int n_prof_params = specifiedvars_.size();
 
     if(!skipdefaultstart_) {
-        std::vector<float> default_start_pt_vec(n_prof_params);
+        std::vector<double> default_start_pt_vec(n_prof_params);
         for (int prof_param_idx = 0; prof_param_idx<n_prof_params; prof_param_idx++){
             default_start_pt_vec[prof_param_idx] = specifiedvars_[prof_param_idx]->getVal();
         }
@@ -54,19 +54,19 @@ std::vector<std::vector<float>> RandStartPt::vectorOfPointsToTry (){
     }
 
     // Append the random points to the vector of points to try
-    float prof_start_pt_range_max = 20.0; // Default to 20 if we're not asking for custom ranges
-    std::map<std::string, std::vector<float>> rand_ranges_dict;
+    double prof_start_pt_range_max = 20.0; // Default to 20 if we're not asking for custom ranges
+    std::map<std::string, std::vector<double>> rand_ranges_dict;
     if (parameterRandInitialValranges_ != "") {
         rand_ranges_dict = RandStartPt::getRangesDictFromInString(parameterRandInitialValranges_);
     }
 
     for (int pt_idx = 0; pt_idx<numrandpts_; pt_idx++){
-        std::vector<float> wc_vals_vec;
+        std::vector<double> wc_vals_vec;
         for (int prof_param_idx=0; prof_param_idx<n_prof_params; prof_param_idx++) {
             if (parameterRandInitialValranges_ != "") {
                 if (rand_ranges_dict.find(specifiedvars_[prof_param_idx]->GetName()) != rand_ranges_dict.end()){   //if the random starting point range for this floating POI was supplied during runtime
-                    float rand_range_lo = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][0];
-                    float rand_range_hi = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][1];
+                    double rand_range_lo = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][0];
+                    double rand_range_hi = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][1];
                     prof_start_pt_range_max = std::max(std::abs(rand_range_lo), std::abs(rand_range_hi));
                 }
                 else {   //if the random starting point range for this floating POI was not supplied during runtime, set the default low to -20 and high to +20
@@ -74,7 +74,7 @@ std::vector<std::vector<float>> RandStartPt::vectorOfPointsToTry (){
                 }
             }
             //Get a random number in the range [-prof_start_pt_range_max,prof_start_pt_range_max]
-            float rand_num = (rand()*2.0*prof_start_pt_range_max)/RAND_MAX - prof_start_pt_range_max;
+            double rand_num = (rand()*2.0*prof_start_pt_range_max)/RAND_MAX - prof_start_pt_range_max;
             wc_vals_vec.push_back(rand_num);
         }
     wc_vals_vec_of_vec.push_back(wc_vals_vec);
@@ -98,8 +98,8 @@ std::vector<std::vector<float>> RandStartPt::vectorOfPointsToTry (){
 
 // Extract the ranges map from the input string
 // // Assumes the string is formatted with colons like "poi_name1=lo_lim,hi_lim:poi_name2=lo_lim,hi_lim"
-std::map<std::string, std::vector<float>> RandStartPt::getRangesDictFromInString(std::string params_ranges_string_in) {
-    std::map<std::string, std::vector<float>> out_range_dict;
+std::map<std::string, std::vector<double>> RandStartPt::getRangesDictFromInString(std::string params_ranges_string_in) {
+    std::map<std::string, std::vector<double>> out_range_dict;
     std::vector<std::string> params_ranges_string_lst = Utils::split(params_ranges_string_in, ":");
     for (UInt_t p = 0; p < params_ranges_string_lst.size(); ++p) {
         std::vector<std::string> params_ranges_string = Utils::split(params_ranges_string_lst[p], "=,");
@@ -107,14 +107,14 @@ std::map<std::string, std::vector<float>> RandStartPt::getRangesDictFromInString
             std::cout << "Error parsing expression : " << params_ranges_string_lst[p] << std::endl;
         }
         std::string wc_name =params_ranges_string[0];
-        float lim_lo = atof(params_ranges_string[1].c_str());
-        float lim_hi = atof(params_ranges_string[2].c_str());
+        double lim_lo = atof(params_ranges_string[1].c_str());
+        double lim_hi = atof(params_ranges_string[2].c_str());
         out_range_dict.insert({wc_name,{lim_lo,lim_hi}});
     }
     return out_range_dict;
 }
 
-void RandStartPt::commitBestNLLVal(unsigned int idx, float &nllVal, double &probVal){//, RooAbsReal& nll_){
+void RandStartPt::commitBestNLLVal(unsigned int idx, double &nllVal, double &probVal){//, RooAbsReal& nll_){
     if (idx==0){
         Combine::commitPoint(true, /*quantile=*/probVal);
         nllVal = nll_.getVal();
@@ -124,7 +124,7 @@ void RandStartPt::commitBestNLLVal(unsigned int idx, float &nllVal, double &prob
     }
 }
 
-void RandStartPt::setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<float>> &nested_vector_of_wc_vals){
+void RandStartPt::setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<double>> &nested_vector_of_wc_vals){
     if (verbosity_ > 1) std::cout << "\n\tStart pt idx: " << startptIdx << std::endl;
     for (unsigned int var_idx = 0; var_idx<specifiedvars_.size(); var_idx++){
         if (verbosity_ > 1) std::cout << "\t\tThe var name: " << specifiedvars_[var_idx]->GetName() << std::endl;
@@ -148,10 +148,10 @@ void RandStartPt::setValSpecifiedObjs(){
     }
 }
 
-void RandStartPt::doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, float &deltaNLL, double &nll_init, CascadeMinimizer &minimObj){
-    float current_best_nll = 0;
+void RandStartPt::doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, CascadeMinimizer &minimObj){
+    double current_best_nll = 0;
     //the nested vector to hold random starting points to try
-    std::vector<std::vector<float>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
+    std::vector<std::vector<double>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
     for (unsigned int start_pt_idx = 0; start_pt_idx<nested_vector_of_wc_vals.size(); start_pt_idx++){
         *param = snap;
         poival[0] = xval;
@@ -183,10 +183,10 @@ void RandStartPt::doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, 
     }
 }
 
-void RandStartPt::doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, float &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj){
-    float current_best_nll = 0;
+void RandStartPt::doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj){
+    double current_best_nll = 0;
     //the nested vector to hold random starting points to try
-    std::vector<std::vector<float>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
+    std::vector<std::vector<double>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
     for (unsigned int start_pt_idx = 0; start_pt_idx<nested_vector_of_wc_vals.size(); start_pt_idx++){
         *param = snap;
         poival[0] = xval;

--- a/src/Significance.cc
+++ b/src/Significance.cc
@@ -30,11 +30,11 @@ using namespace std;
 //std::string Significance::minimizerAlgo_ = "Minuit2";
 std::string Significance::minimizerAlgoForBF_ = "Minuit2,simplex";
 //float       Significance::minimizerTolerance_ = 1e-2;
-float Significance::minimizerToleranceForBF_ = 1e-4;
+double Significance::minimizerToleranceForBF_ = 1e-4;
 int Significance::tries_ = 1;
 int Significance::maxTries_ = 1;
-float Significance::maxRelDeviation_ = 0.05;
-float Significance::maxOutlierFraction_ = 0.25;
+double Significance::maxRelDeviation_ = 0.05;
+double Significance::maxOutlierFraction_ = 0.25;
 int Significance::maxOutliers_ = 3;
 int Significance::points_ = 20;
 bool Significance::preFit_ = false;
@@ -43,8 +43,8 @@ bool Significance::bruteForce_ = false;
 std::string Significance::bfAlgo_ = "scale";
 bool Significance::reportPVal_ = false;
 bool Significance::uncapped_ = false;
-float Significance::signalForSignificance_ = 0;
-float Significance::mass_;
+double Significance::signalForSignificance_ = 0;
+double Significance::mass_;
 std::string Significance::plot_ = "";
 
 Significance::Significance() : LimitAlgo("Significance specific options") {
@@ -58,13 +58,13 @@ Significance::Significance() : LimitAlgo("Significance specific options") {
           boost::program_options::value<int>(&maxTries_)->default_value(maxTries_),
           "Stop trying after N attempts per point")(
           "maxRelDeviation",
-          boost::program_options::value<float>(&maxRelDeviation_)->default_value(maxOutlierFraction_),
+          boost::program_options::value<double>(&maxRelDeviation_)->default_value(maxOutlierFraction_),
           "Max absolute deviation of the results from the median")(
           "maxOutlierFraction",
-          boost::program_options::value<float>(&maxOutlierFraction_)->default_value(maxOutlierFraction_),
+          boost::program_options::value<double>(&maxOutlierFraction_)->default_value(maxOutlierFraction_),
           "Ignore up to this fraction of results if they're too far from the median")(
           "signalForSignificance",
-          boost::program_options::value<float>(&signalForSignificance_)->default_value(signalForSignificance_),
+          boost::program_options::value<double>(&signalForSignificance_)->default_value(signalForSignificance_),
           "Signal strength used when computing significances (default is zero, just background)")(
           "maxOutliers",
           boost::program_options::value<int>(&maxOutliers_)->default_value(maxOutliers_),
@@ -89,7 +89,7 @@ Significance::Significance() : LimitAlgo("Significance specific options") {
           boost::program_options::value<std::string>(&minimizerAlgoForBF_)->default_value(minimizerAlgoForBF_),
           "Choice of minimizer for brute-force search (default is Minuit2,simplex)")(
           "setBruteForceTolerance",
-          boost::program_options::value<float>(&minimizerToleranceForBF_)->default_value(minimizerToleranceForBF_),
+          boost::program_options::value<double>(&minimizerToleranceForBF_)->default_value(minimizerToleranceForBF_),
           "Tolerance for minimizer when doing brute-force search");
 }
 
@@ -102,7 +102,7 @@ void Significance::applyOptions(const boost::program_options::variables_map &vm)
     useMinos_ = true;
   bruteForce_ = vm.count("bruteForce");
   reportPVal_ = vm.count("pvalue");
-  mass_ = vm["mass"].as<float>();
+  mass_ = vm["mass"].as<double>();
 }
 
 Significance::MinimizerSentry::MinimizerSentry(const std::string &minimizerAlgo, double tolerance)


### PR DESCRIPTION
## Summary
- promote cascade minimizer tolerances and pruning threshold to double precision
- adjust fallback algorithm configuration to use double values
- convert POI handling, random start points, goodness-of-fit metrics, and MCMC configs from float to double for consistent high-precision tracking

## Testing
- `make -C test/unit` *(fails: `TFile.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4da377b488329acb45952537cfaa4