### PR TITLE
Optimize minimizer memory usage

### DIFF
--- a/interface/MarkovChainMC.h
+++ b/interface/MarkovChainMC.h
@@ -10,6 +10,7 @@
  */
 #include "LimitAlgo.h"
 #include <TList.h>
+#include <vector>
 class RooArgSet;
 namespace RooStats { class MarkovChain; }
 
@@ -71,10 +72,10 @@ private:
   // return number of items in chain, 0 for error
   int runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) const ;
 
-  RooStats::MarkovChain *mergeChains(const RooArgSet &poi, const std::vector<double> &limits) const;
-  void readChains(const RooArgSet &poi, std::vector<double> &limits);
+  RooStats::MarkovChain *mergeChains(const RooArgSet &poi, const std::vector<float> &limits) const;
+  void readChains(const RooArgSet &poi, std::vector<float> &limits);
   void limitFromChain(double &limit, double &limitErr, const RooArgSet &poi, RooStats::MarkovChain &chain, int burnInSteps=-1 /* -1 = use default */) ;
-  void limitAndError(double &limit, double &limitErr, const std::vector<double> &limits) const ;
+  void limitAndError(double &limit, double &limitErr, const std::vector<float> &limits) const ;
   RooStats::MarkovChain *slimChain(const RooArgSet &poi, const RooStats::MarkovChain &chain) const;
   int  guessBurnInSteps(const RooStats::MarkovChain &chain) const;
 

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -12,6 +12,7 @@
 #include <RooRealVar.h>
 #include "TFile.h"
 #include <vector>
+#include <map>
 #include <TFile.h>
 
 class MultiDimFit : public FitterAlgoBase {
@@ -35,7 +36,7 @@ protected:
 
   static std::vector<std::string>  poi_;
   static std::vector<RooRealVar*>  poiVars_;
-  static std::vector<double>       poiVals_;
+  static std::vector<float>       poiVals_;
   static RooArgList                poiList_;
   static unsigned int              nOtherFloatingPoi_; // keep a count of other POIs that we're ignoring, for proper chisquare normalization
   static double                    deltaNLL_;
@@ -77,7 +78,7 @@ protected:
   static std::string saveSpecifiedIndex_;
   static std::vector<std::string>  specifiedFuncNames_;
   static std::vector<RooAbsReal*> specifiedFunc_;
-  static std::vector<double>       specifiedFuncVals_;
+  static std::vector<float>       specifiedFuncVals_;
   static RooArgList                specifiedFuncList_;
   static std::vector<std::string>  specifiedCatNames_;
   static std::vector<RooCategory*> specifiedCat_;
@@ -85,7 +86,7 @@ protected:
   static RooArgList                specifiedCatList_;
   static std::vector<std::string>  specifiedNuis_;
   static std::vector<RooRealVar *> specifiedVars_;
-  static std::vector<double>       specifiedVals_;
+  static std::vector<float>       specifiedVals_;
   static RooArgList                specifiedList_;
   static bool saveInactivePOI_;
   static bool skipDefaultStart_;
@@ -101,7 +102,7 @@ protected:
   void doStitch2D(RooWorkspace *w, RooAbsReal &nll) ;
   void doImpact(RooFitResult &res, RooAbsReal &nll) ;
 
-  std::map<std::string, std::vector<double>> getRangesDictFromInString(std::string) ;
+  std::map<std::string, std::vector<float>> getRangesDictFromInString(std::string) ;
 
 
   // utilities

--- a/interface/RandStartPt.h
+++ b/interface/RandStartPt.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 #include "RooRealVar.h"
 #include "RooAbsReal.h"
 #include "RooArgSet.h"
@@ -15,7 +16,7 @@ class RandStartPt {
   private:
       RooAbsReal& nll_;
       std::vector<RooRealVar* > &specifiedvars_;
-      std::vector<double> &specifiedvals_;
+      std::vector<float> &specifiedvals_;
       bool skipdefaultstart_;
       std::string parameterRandInitialValranges_;
       int numrandpts_;
@@ -26,20 +27,20 @@ class RandStartPt {
       std::vector<std::string> &specifiednuis_;
       std::vector<std::string> &specifiedfuncnames_;
       std::vector<RooAbsReal*> &specifiedfunc_;
-      std::vector<double> &specifiedfuncvals_;
+      std::vector<float> &specifiedfuncvals_;
       std::vector<std::string> &specifiedcatnames_; 
       std::vector<RooCategory*> &specifiedcat_; 
       std::vector<int> &specifiedcatvals_;
       unsigned int nOtherFloatingPOI_;
   public:
-      RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<double> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, double maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<double> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI);
-      std::map<std::string, std::vector<double>> getRangesDictFromInString(std::string params_ranges_string_in);
-      std::vector<std::vector<double>> vectorOfPointsToTry ();
+      RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<float> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, double maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<float> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI);
+      std::map<std::string, std::vector<float>> getRangesDictFromInString(std::string params_ranges_string_in);
+      std::vector<std::vector<float>> vectorOfPointsToTry ();
       void commitBestNLLVal(unsigned int idx, double &nllVal, double &probVal);
-      void setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<double>> &nested_vector_of_wc_vals);
+      void setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<float>> &nested_vector_of_wc_vals);
       void setValSpecifiedObjs();
-      void doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, CascadeMinimizer &minimObj);
-      void doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj);
+      void doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, CascadeMinimizer &minimObj);
+      void doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj);
 
 };
 #endif

--- a/src/MarkovChainMC.cc
+++ b/src/MarkovChainMC.cc
@@ -144,7 +144,7 @@ bool MarkovChainMC::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::
 
   double suma = 0; int num = 0;
   double savhint = (hint ? *hint : -1); const double *thehint = hint;
-  std::vector<double> limits;
+  std::vector<float> limits;
   if (readChains_)  {
       readChains(*mc_s->GetParametersOfInterest(), limits);
   } else {
@@ -345,8 +345,8 @@ int MarkovChainMC::runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
   }
 }
 
-void MarkovChainMC::limitAndError(double &limit, double &limitErr, const std::vector<double> &limitsIn) const {
-  std::vector<double> limits(limitsIn);
+void MarkovChainMC::limitAndError(double &limit, double &limitErr, const std::vector<float> &limitsIn) const {
+  std::vector<float> limits(limitsIn);
   int num = limits.size();
   // possibly remove outliers before computing mean
   if (adaptiveTruncation_ && num >= 10) {
@@ -378,7 +378,7 @@ void MarkovChainMC::limitAndError(double &limit, double &limitErr, const std::ve
 #endif
   } else {
       int noutl = floor(truncatedMeanFraction_ * num);
-      if (noutl >= 1) { 
+      if (noutl >= 1) {
           std::sort(limits.begin(), limits.end());
           double median = (num % 2 ? limits[num/2] : 0.5*(limits[num/2] + limits[num/2+1]));
           for (int k = 0; k < noutl; ++k) {
@@ -398,9 +398,9 @@ void MarkovChainMC::limitAndError(double &limit, double &limitErr, const std::ve
   }
 }
 
-RooStats::MarkovChain *MarkovChainMC::mergeChains(const RooArgSet &poi, const std::vector<double> &limits) const
+RooStats::MarkovChain *MarkovChainMC::mergeChains(const RooArgSet &poi, const std::vector<float> &limits) const
 {
-    std::vector<double> limitsSorted(limits); std::sort(limitsSorted.begin(), limitsSorted.end());
+    std::vector<float> limitsSorted(limits); std::sort(limitsSorted.begin(), limitsSorted.end());
     double lmin = limitsSorted.front(), lmax = limitsSorted.back();
     if (limitsSorted.size() > 5) {
         int n = limitsSorted.size();
@@ -431,7 +431,7 @@ RooStats::MarkovChain *MarkovChainMC::mergeChains(const RooArgSet &poi, const st
     return merged;
 }
 
-void MarkovChainMC::readChains(const RooArgSet &poi, std::vector<double> &limits)
+void MarkovChainMC::readChains(const RooArgSet &poi, std::vector<float> &limits)
 {
     double mylim, myerr;
     chains_.Clear();
@@ -507,7 +507,7 @@ int
 MarkovChainMC::guessBurnInSteps(const RooStats::MarkovChain &chain) const
 {
     int n = chain.Size();
-    std::vector<double> nll(n);
+    std::vector<float> nll(n);
     for (int i = 0; i < n; ++i) {
         nll[i] = chain.NLL(i);
     }
@@ -532,7 +532,7 @@ int
 MarkovChainMC::stationarityTest(const RooStats::MarkovChain &chain, const RooArgSet &poi, int nchunks) const 
 {
     std::vector<int>    entries(nchunks, 0);
-    std::vector<double> mean(nchunks, .0);
+    std::vector<float> mean(nchunks, .0f);
     const RooDataSet *data = chain.GetAsConstDataSet();
     const RooRealVar *r = dynamic_cast<const RooRealVar *>(data->get()->find(poi.first()->GetName()));
     int  n = data->numEntries(), chunksize = ceil(n/double(nchunks));
@@ -544,7 +544,7 @@ MarkovChainMC::stationarityTest(const RooStats::MarkovChain &chain, const RooArg
     }
     for (int c = 0; c < nchunks; ++c) { mean[c] /= entries[c]; }
 
-    std::vector<double> dists, dists25;
+    std::vector<float> dists, dists25;
     for (int c = 0; c < nchunks; ++c) {
         for (int c2 = 0; c2 < nchunks; ++c2) {
             if (c2 != c) dists.push_back(fabs(mean[c]-mean[c2]));

--- a/src/RandStartPt.cc
+++ b/src/RandStartPt.cc
@@ -6,6 +6,7 @@
 #include <vector>
 #include <iostream>
 #include <cmath>
+#include <map>
 
 #include "TMath.h"
 #include "TFile.h"
@@ -19,7 +20,7 @@
 #include <Math/QuantFuncMathCore.h>
 #include <Math/ProbFunc.h>
 
-RandStartPt::RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<double> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, double maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<double> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI) :
+RandStartPt::RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedvars, std::vector<float> &specifiedvals, bool skipdefaultstart, std::string parameterRandInitialValranges, int numrandpts, int verbose, bool fastscan, bool hasmaxdeltaNLLforprof, double maxdeltaNLLforprof, std::vector<std::string> &specifiednuis, std::vector<std::string> &specifiedfuncnames, std::vector<RooAbsReal*> &specifiedfunc, std::vector<float> &specifiedfuncvals, std::vector<std::string> &specifiedcatnames, std::vector<RooCategory*> &specifiedcat, std::vector<int> &specifiedcatvals, unsigned int nOtherFloatingPOI) :
     nll_(nll),
     specifiedvars_(specifiedvars),
     specifiedvals_(specifiedvals),
@@ -41,12 +42,12 @@ RandStartPt::RandStartPt(RooAbsReal& nll, std::vector<RooRealVar* > &specifiedva
 
     {}
 
-std::vector<std::vector<double>> RandStartPt::vectorOfPointsToTry (){
-    std::vector<std::vector<double>> wc_vals_vec_of_vec = {};
+std::vector<std::vector<float>> RandStartPt::vectorOfPointsToTry (){
+    std::vector<std::vector<float>> wc_vals_vec_of_vec = {};
     int n_prof_params = specifiedvars_.size();
 
     if(!skipdefaultstart_) {
-        std::vector<double> default_start_pt_vec(n_prof_params);
+        std::vector<float> default_start_pt_vec(n_prof_params);
         for (int prof_param_idx = 0; prof_param_idx<n_prof_params; prof_param_idx++){
             default_start_pt_vec[prof_param_idx] = specifiedvars_[prof_param_idx]->getVal();
         }
@@ -54,27 +55,27 @@ std::vector<std::vector<double>> RandStartPt::vectorOfPointsToTry (){
     }
 
     // Append the random points to the vector of points to try
-    double prof_start_pt_range_max = 20.0; // Default to 20 if we're not asking for custom ranges
-    std::map<std::string, std::vector<double>> rand_ranges_dict;
+    float prof_start_pt_range_max = 20.0f; // Default to 20 if we're not asking for custom ranges
+    std::map<std::string, std::vector<float>> rand_ranges_dict;
     if (parameterRandInitialValranges_ != "") {
         rand_ranges_dict = RandStartPt::getRangesDictFromInString(parameterRandInitialValranges_);
     }
 
     for (int pt_idx = 0; pt_idx<numrandpts_; pt_idx++){
-        std::vector<double> wc_vals_vec;
+        std::vector<float> wc_vals_vec;
         for (int prof_param_idx=0; prof_param_idx<n_prof_params; prof_param_idx++) {
             if (parameterRandInitialValranges_ != "") {
                 if (rand_ranges_dict.find(specifiedvars_[prof_param_idx]->GetName()) != rand_ranges_dict.end()){   //if the random starting point range for this floating POI was supplied during runtime
-                    double rand_range_lo = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][0];
-                    double rand_range_hi = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][1];
+                    float rand_range_lo = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][0];
+                    float rand_range_hi = rand_ranges_dict[specifiedvars_[prof_param_idx]->GetName()][1];
                     prof_start_pt_range_max = std::max(std::abs(rand_range_lo), std::abs(rand_range_hi));
                 }
                 else {   //if the random starting point range for this floating POI was not supplied during runtime, set the default low to -20 and high to +20
-                    rand_ranges_dict.insert({specifiedvars_[prof_param_idx]->GetName(),{-20.0,20.0}});
+                    rand_ranges_dict.insert({specifiedvars_[prof_param_idx]->GetName(),{-20.f,20.f}});
                 }
             }
             //Get a random number in the range [-prof_start_pt_range_max,prof_start_pt_range_max]
-            double rand_num = (rand()*2.0*prof_start_pt_range_max)/RAND_MAX - prof_start_pt_range_max;
+            float rand_num = (rand()*2.0f*prof_start_pt_range_max)/RAND_MAX - prof_start_pt_range_max;
             wc_vals_vec.push_back(rand_num);
         }
     wc_vals_vec_of_vec.push_back(wc_vals_vec);
@@ -98,8 +99,8 @@ std::vector<std::vector<double>> RandStartPt::vectorOfPointsToTry (){
 
 // Extract the ranges map from the input string
 // // Assumes the string is formatted with colons like "poi_name1=lo_lim,hi_lim:poi_name2=lo_lim,hi_lim"
-std::map<std::string, std::vector<double>> RandStartPt::getRangesDictFromInString(std::string params_ranges_string_in) {
-    std::map<std::string, std::vector<double>> out_range_dict;
+std::map<std::string, std::vector<float>> RandStartPt::getRangesDictFromInString(std::string params_ranges_string_in) {
+    std::map<std::string, std::vector<float>> out_range_dict;
     std::vector<std::string> params_ranges_string_lst = Utils::split(params_ranges_string_in, ":");
     for (UInt_t p = 0; p < params_ranges_string_lst.size(); ++p) {
         std::vector<std::string> params_ranges_string = Utils::split(params_ranges_string_lst[p], "=,");
@@ -107,8 +108,8 @@ std::map<std::string, std::vector<double>> RandStartPt::getRangesDictFromInStrin
             std::cout << "Error parsing expression : " << params_ranges_string_lst[p] << std::endl;
         }
         std::string wc_name =params_ranges_string[0];
-        double lim_lo = atof(params_ranges_string[1].c_str());
-        double lim_hi = atof(params_ranges_string[2].c_str());
+        float lim_lo = atof(params_ranges_string[1].c_str());
+        float lim_hi = atof(params_ranges_string[2].c_str());
         out_range_dict.insert({wc_name,{lim_lo,lim_hi}});
     }
     return out_range_dict;
@@ -124,7 +125,7 @@ void RandStartPt::commitBestNLLVal(unsigned int idx, double &nllVal, double &pro
     }
 }
 
-void RandStartPt::setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<double>> &nested_vector_of_wc_vals){
+void RandStartPt::setProfPOIvalues(unsigned int startptIdx, std::vector<std::vector<float>> &nested_vector_of_wc_vals){
     if (verbosity_ > 1) std::cout << "\n\tStart pt idx: " << startptIdx << std::endl;
     for (unsigned int var_idx = 0; var_idx<specifiedvars_.size(); var_idx++){
         if (verbosity_ > 1) std::cout << "\t\tThe var name: " << specifiedvars_[var_idx]->GetName() << std::endl;
@@ -148,10 +149,10 @@ void RandStartPt::setValSpecifiedObjs(){
     }
 }
 
-void RandStartPt::doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, CascadeMinimizer &minimObj){
+void RandStartPt::doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, CascadeMinimizer &minimObj){
     double current_best_nll = 0;
     //the nested vector to hold random starting points to try
-    std::vector<std::vector<double>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
+    std::vector<std::vector<float>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
     for (unsigned int start_pt_idx = 0; start_pt_idx<nested_vector_of_wc_vals.size(); start_pt_idx++){
         *param = snap;
         poival[0] = xval;
@@ -183,10 +184,10 @@ void RandStartPt::doRandomStartPt1DGridScan(double &xval, unsigned int poiSize, 
     }
 }
 
-void RandStartPt::doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<double> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj){
+void RandStartPt::doRandomStartPt2DGridScan(double &xval, double &yval, unsigned int poiSize, std::vector<float> &poival, std::vector<RooRealVar* > &poivars, std::unique_ptr <RooArgSet> &param, RooArgSet &snap, double &deltaNLL, double &nll_init, MultiDimFit::GridType gridType, double deltaX, double deltaY, CascadeMinimizer &minimObj){
     double current_best_nll = 0;
     //the nested vector to hold random starting points to try
-    std::vector<std::vector<double>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
+    std::vector<std::vector<float>> nested_vector_of_wc_vals =  vectorOfPointsToTry ();
     for (unsigned int start_pt_idx = 0; start_pt_idx<nested_vector_of_wc_vals.size(); start_pt_idx++){
         *param = snap;
         poival[0] = xval;


### PR DESCRIPTION
## Summary
- Use `float` containers for limit calculations in `MarkovChainMC`
- Track POI and nuisance values with `float` storage in `MultiDimFit`
- Update random start point utilities to operate on `float` vectors

## Testing
- `make` *(failed: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0d2d6208329af8e1c1e7f0b26a5