### PR TITLE
Honor requested minimizer without fallback

### DIFF
--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -8,6 +8,8 @@
 
 #include <Math/MinimizerOptions.h>
 #include <Math/IOptions.h>
+#include <Math/Factory.h>
+#include <Math/Minimizer.h>
 #include <RooCategory.h>
 #include <RooNumIntConfig.h>
 #include <TStopwatch.h>
@@ -18,6 +20,7 @@
 #include <cstdlib>
 #include <set>
 #include <stdexcept>
+#include <memory>
 
 boost::program_options::options_description CascadeMinimizer::options_("Cascade Minimizer options");
 std::vector<CascadeMinimizer::Algo> CascadeMinimizer::fallbacks_;
@@ -948,7 +951,6 @@ bool CascadeMinimizer::checkAlgoInType(std::string type, std::string algo) {
 
 void CascadeMinimizer::applyOptions(const boost::program_options::variables_map &vm) {
   using namespace std;
-  int verbose = vm.count("verbose") ? vm["verbose"].as<int>() : 0;
   preScan_ = vm.count("cminPreScan");
   poiOnlyFit_ = vm.count("cminPoiOnlyFit");
   singleNuisFit_ = vm.count("cminSingleNuisFit");
@@ -1063,6 +1065,16 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
       throw std::runtime_error("Failed to load libCeresMinimizer");
     }
     setenv("CERES_ALGO", defaultMinimizerAlgo_.c_str(), 1);
+    std::unique_ptr<ROOT::Math::Minimizer> probe{
+        ROOT::Math::Factory::CreateMinimizer("Ceres", defaultMinimizerAlgo_.c_str())};
+    if (!probe) {
+      CombineLogger::instance().log(
+          "CascadeMinimizer.cc",
+          __LINE__,
+          "[FATAL] Failed to create Ceres minimizer. Ensure Ceres is correctly built and available.",
+          __func__);
+      throw std::runtime_error("Failed to create Ceres minimizer");
+    }
   }
   // Note that the options are not applied again when recreating a CascadeMinimizer so need to set the global attributes (should we make the modifiable options persistant too?)
   ROOT::Math::MinimizerOptions::SetDefaultMinimizer(defaultMinimizerType_.c_str(), defaultMinimizerAlgo_.c_str());

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -151,9 +151,6 @@ void FitterAlgoBase::applyOptionsBase(const boost::program_options::variables_ma
     minimizerAlgoForMinos_ = Form("%s,%s",
                                   ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str(),
                                   ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str());
-    if (ROOT::Math::MinimizerOptions::DefaultMinimizerType() == std::string("Ceres")) {
-      minimizerAlgoForMinos_ = "Minuit2,Migrad";
-    }
   }
   if (!vm.count("setRobustFitTolerance") || vm["setRobustFitTolerance"].defaulted()) {
     minimizerToleranceForMinos_ = ROOT::Math::MinimizerOptions::

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -1022,8 +1022,8 @@ void MultiDimFit::doFixedPoint(RooWorkspace *w, RooAbsReal &nll)
 void MultiDimFit::doContour2D(RooWorkspace *, RooAbsReal &nll) 
 {
     if (poi_.size() != 2) throw std::logic_error("Contour2D works only in 2 dimensions");
-    RooRealVar *xv = poiVars_[0]; double x0 = poiVals_[0]; double &x = poiVals_[0];
-    RooRealVar *yv = poiVars_[1]; double y0 = poiVals_[1]; double &y = poiVals_[1];
+    RooRealVar *xv = poiVars_[0]; double x0 = poiVals_[0]; float &x = poiVals_[0];
+    RooRealVar *yv = poiVars_[1]; double y0 = poiVals_[1]; float &y = poiVals_[1];
 
     double threshold = nll.getVal() + 0.5*ROOT::Math::chisquared_quantile_c(1-cl,2+nOtherFloatingPoi_);
     if (verbose>0) CombineLogger::instance().log("MultiDimFit.cc",__LINE__,std::string(Form("Best fit point is for %s, %s, = %.4f,%.4f",xv->GetName(),yv->GetName(),x0,y0)),__func__);

--- a/src/Significance.cc
+++ b/src/Significance.cc
@@ -23,6 +23,11 @@
 #include "../interface/CombineLogger.h"
 
 #include <Math/MinimizerOptions.h>
+#include <Math/Factory.h>
+#include <Math/Minimizer.h>
+#include <TSystem.h>
+#include <memory>
+#include <stdexcept>
 
 using namespace RooStats;
 using namespace std;
@@ -134,6 +139,29 @@ Significance::MinimizerSentry::MinimizerSentry(const std::string &minimizerAlgo,
           __func__);
     }
     ROOT::Math::MinimizerOptions::SetDefaultMinimizer(minimizerAlgo.c_str());
+  }
+
+  if (ROOT::Math::MinimizerOptions::DefaultMinimizerType() == "Ceres") {
+    int loadStatus = gSystem->Load("libCeresMinimizer");
+    if (loadStatus < 0) {
+      CombineLogger::instance().log(
+          "Significance.cc",
+          __LINE__,
+          "[FATAL] Failed to load libCeresMinimizer. Rebuild with Ceres support or choose a supported minimizer.",
+          __func__);
+      throw std::runtime_error("Failed to load libCeresMinimizer");
+    }
+    setenv("CERES_ALGO", ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str(), 1);
+    std::unique_ptr<ROOT::Math::Minimizer> probe{
+        ROOT::Math::Factory::CreateMinimizer("Ceres", ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str())};
+    if (!probe) {
+      CombineLogger::instance().log(
+          "Significance.cc",
+          __LINE__,
+          "[FATAL] Failed to create Ceres minimizer. Ensure Ceres is correctly built and available.",
+          __func__);
+      throw std::runtime_error("Failed to create Ceres minimizer");
+    }
   }
 }
 
@@ -392,10 +420,8 @@ double Significance::upperLimitWithMinos(
   double muhat = poi.getVal();
   double limit = 0.0;
   {
-    std::string minAlgo = ROOT::Math::MinimizerOptions::DefaultMinimizerType() == std::string("Ceres")
-                              ? std::string("Minuit2,Migrad")
-                              : ROOT::Math::MinimizerOptions::DefaultMinimizerType() + "," +
-                                    ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
+    std::string minAlgo = ROOT::Math::MinimizerOptions::DefaultMinimizerType() + "," +
+                          ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
     MinimizerSentry minimizerConfig(minAlgo, tolerance);
     int minosStat = minim.minos(RooArgSet(poi));
     if (minosStat == -1) {


### PR DESCRIPTION
## Summary
- Load Ceres plugin and abort when the minimizer cannot be created
- Remove hardcoded Minuit2 fallback so robust fits respect the selected minimizer
- Let Significance calculations use whatever minimizer is requested instead of forcing Minuit2
- Ensure Ceres is loaded for Significance runs and include missing ROOT Minimizer header
- Fix MultiDimFit's 2D contour code to reference float `poiVals_` correctly

## Testing
- `make build/obj/MultiDimFit.o` *(fails: root-config: No such file or directory)*
- `make -C test/unit` *(fails: TFile.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e52fe13c8329a7dda499c6bb061e