### PR TITLE
Fix Ceres minimizer dictionary installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,18 @@ if(Ceres_FOUND)
   add_library(CeresMinimizer SHARED ceres/CeresMinimizer.cc G__CeresMinimizer.cxx)
   target_link_libraries(CeresMinimizer PUBLIC ${ROOT_LIBRARIES} Ceres::ceres)
   target_include_directories(CeresMinimizer PUBLIC ${Ceres_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+  # Ensure the ROOT dictionary and rootmap are placed next to the plugin library
+  add_custom_command(TARGET CeresMinimizer POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer_rdict.pcm
+            $<TARGET_FILE_DIR:CeresMinimizer>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer.rootmap
+            $<TARGET_FILE_DIR:CeresMinimizer>)
   install(TARGETS CeresMinimizer LIBRARY DESTINATION lib)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer_rdict.pcm DESTINATION lib)
+  install(FILES $<TARGET_FILE_DIR:CeresMinimizer>/libCeresMinimizer_rdict.pcm
+                $<TARGET_FILE_DIR:CeresMinimizer>/libCeresMinimizer.rootmap
+          DESTINATION lib)
 else()
   message(STATUS "Ceres not found - CeresMinimizer plugin will be unavailable")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,10 @@ ifdef CERES
 $(CERES_OBJ): $(CERES_SRC) $(INC_DIR)/CeresMinimizer.h | $(OBJ_DIR)
 	$(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) -c $< -o $@
 
-$(CERES_DICT): $(INC_DIR)/CeresMinimizer.h $(CERES_DICT_HDR) | $(OBJ_DIR)
-	rootcling -f $@ -s $(CERES_SONAME) -I$(INC_DIR) -I$(SRC_DIR) $(CERES_INC) $(CERES_DEFS) $^
+$(CERES_DICT): $(INC_DIR)/CeresMinimizer.h $(CERES_DICT_HDR) | $(OBJ_DIR) $(LIB_DIR)
+       rootcling -f $@ -s $(CERES_SONAME) -I$(INC_DIR) -I$(SRC_DIR) $(CERES_INC) $(CERES_DEFS) $^
+       mv $(OBJ_DIR)/a/lib$(CERES_LIBNAME)_rdict.pcm $(LIB_DIR)/
+       mv $(OBJ_DIR)/a/lib$(CERES_LIBNAME).rootmap $(LIB_DIR)/
 
 $(CERES_DICT_OBJ): $(CERES_DICT) | $(OBJ_DIR)
 	$(CXX) $(CCFLAGS) -I . -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) -c $< -o $@


### PR DESCRIPTION
## Summary
- Copy Ceres minimizer ROOT dictionary and rootmap next to the plugin library and install them
- Ensure Makefile build also moves the generated dictionary/rootmap into the lib directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ROOT'; ModuleNotFoundError: No module named 'six')*

------
https://chatgpt.com/codex/tasks/task_e_68b500c051108329ac9a58b4af7d2cfd