### PR TITLE
Fix Ceres plugin dictionary placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,26 @@ target_link_libraries(combine PUBLIC ${LIBNAME})
 
 if(Ceres_FOUND)
   message(STATUS "Found Ceres - building CeresMinimizer plugin")
-  ROOT_GENERATE_DICTIONARY(G__CeresMinimizer interface/CeresMinimizer.h LINKDEF ceres/CeresMinimizer_LinkDef.h MODULE CeresMinimizer)
+  ROOT_GENERATE_DICTIONARY(G__CeresMinimizer
+    interface/CeresMinimizer.h
+    LINKDEF ceres/CeresMinimizer_LinkDef.h
+    MODULE CeresMinimizer
+    OPTIONS "-rml CeresMinimizer -rmf ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer.rootmap")
   add_library(CeresMinimizer SHARED ceres/CeresMinimizer.cc G__CeresMinimizer.cxx)
   target_link_libraries(CeresMinimizer PUBLIC ${ROOT_LIBRARIES} Ceres::ceres)
   target_include_directories(CeresMinimizer PUBLIC ${Ceres_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+  # Ensure the ROOT dictionary and rootmap are placed next to the plugin library
+  add_custom_command(TARGET CeresMinimizer POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer_rdict.pcm
+            $<TARGET_FILE_DIR:CeresMinimizer>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer.rootmap
+            $<TARGET_FILE_DIR:CeresMinimizer>)
   install(TARGETS CeresMinimizer LIBRARY DESTINATION lib)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer_rdict.pcm DESTINATION lib)
+  install(FILES $<TARGET_FILE_DIR:CeresMinimizer>/libCeresMinimizer_rdict.pcm
+                $<TARGET_FILE_DIR:CeresMinimizer>/libCeresMinimizer.rootmap
+          DESTINATION lib)
 else()
   message(STATUS "Ceres not found - CeresMinimizer plugin will be unavailable")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,14 @@ ifdef CERES
 $(CERES_OBJ): $(CERES_SRC) $(INC_DIR)/CeresMinimizer.h | $(OBJ_DIR)
 	$(CXX) $(CCFLAGS) -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) -c $< -o $@
 
-$(CERES_DICT): $(INC_DIR)/CeresMinimizer.h $(CERES_DICT_HDR) | $(OBJ_DIR)
-	rootcling -f $@ -s $(CERES_SONAME) -I$(INC_DIR) -I$(SRC_DIR) $(CERES_INC) $(CERES_DEFS) $^
+$(CERES_DICT): $(INC_DIR)/CeresMinimizer.h $(CERES_DICT_HDR) | $(OBJ_DIR) $(LIB_DIR)
+	rootcling -f $@ \
+		-s $(CERES_SONAME) \
+		-rml $(CERES_SONAME) \
+		-rmf lib$(CERES_LIBNAME).rootmap \
+		-I$(INC_DIR) -I$(SRC_DIR) $(CERES_INC) $(CERES_DEFS) $^
+	mv lib$(CERES_LIBNAME)_rdict.pcm $(LIB_DIR)/
+	mv lib$(CERES_LIBNAME).rootmap $(LIB_DIR)/
 
 $(CERES_DICT_OBJ): $(CERES_DICT) | $(OBJ_DIR)
 	$(CXX) $(CCFLAGS) -I . -I $(INC_DIR) -I $(SRC_DIR) -I $(PARENT_DIR) -c $< -o $@

--- a/ceres/CeresMinimizer.cc
+++ b/ceres/CeresMinimizer.cc
@@ -463,22 +463,13 @@ void CeresMinimizer::ComputeGradientAndHessian(const double *x) {
   }
 }
 
-extern "C" ROOT::Math::Minimizer *createCeresMinimizer()
-    __attribute__((visibility("default"), used));
-
-extern "C" ROOT::Math::Minimizer *createCeresMinimizer() {
-  std::cout << "[DEBUG] createCeresMinimizer called" << std::endl;
-  return new CeresMinimizer();
-}
-
 namespace {
-  ROOT::Math::Minimizer *createCeresMinimizer() { return new CeresMinimizer(); }
   struct CeresMinimizerRegister {
     CeresMinimizerRegister() {
       std::cout << "[DEBUG] Registering Ceres plugin" << std::endl;
       gPluginMgr->AddHandler("ROOT::Math::Minimizer", "Ceres",
                              "CeresMinimizer", "CeresMinimizer",
-                             "createCeresMinimizer()");
+                             "CeresMinimizer()");
       std::cout << "[DEBUG] Added handler for class CeresMinimizer in library CeresMinimizer" << std::endl;
     }
   } gCeresMinimizerRegister;

--- a/ceres/CeresMinimizer_LinkDef.h
+++ b/ceres/CeresMinimizer_LinkDef.h
@@ -3,5 +3,4 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ class CeresMinimizer+;
-#pragma link C++ function createCeresMinimizer;
 #endif


### PR DESCRIPTION
## Summary
- ensure Ceres minimizer dictionary generates a rootmap and place both PCM and rootmap next to the plugin
- provide equivalent CMake options so builds via CMake also ship the rootmap
- register the Ceres minimizer plugin via its class constructor instead of a missing factory function

## Testing
- `make CERES=1 build/obj/a/CeresMinimizerDict.cc` *(fails: rootcling: No such file or directory)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'six')*


------
https://chatgpt.com/codex/tasks/task_e_68b500c051108329ac9a58b4af7d2cfd