### PR TITLE
Handle zero-offset objective in Ceres minimizer and track status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@ find_package(Boost CONFIG REQUIRED COMPONENTS program_options filesystem)
 # The Ceres minimizer is optional. For nonstandard installations (e.g. conda)
 # set Ceres_DIR to the directory containing CeresConfig.cmake so that
 # find_package can locate it.
-find_package(Ceres)
+find_package(Ceres QUIET HINTS $ENV{CERES_PREFIX})
 if(NOT Ceres_FOUND)
-  message(STATUS "Ceres not found. If installed in a nonstandard location (e.g. conda), set Ceres_DIR to the path containing CeresConfig.cmake")
+  message(STATUS "Ceres not found. If installed in a nonstandard location (e.g. conda), set Ceres_DIR or CERES_PREFIX to the path containing CeresConfig.cmake")
 endif()
 
 if(cminDefaultMinimizerType STREQUAL "Ceres" AND NOT Ceres_FOUND)
@@ -70,12 +70,26 @@ target_link_libraries(combine PUBLIC ${LIBNAME})
 
 if(Ceres_FOUND)
   message(STATUS "Found Ceres - building CeresMinimizer plugin")
-  ROOT_GENERATE_DICTIONARY(G__CeresMinimizer interface/CeresMinimizer.h LINKDEF ceres/CeresMinimizer_LinkDef.h MODULE CeresMinimizer)
+  ROOT_GENERATE_DICTIONARY(G__CeresMinimizer
+    interface/CeresMinimizer.h
+    LINKDEF ceres/CeresMinimizer_LinkDef.h
+    MODULE CeresMinimizer
+    OPTIONS "-rml CeresMinimizer -rmf ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer.rootmap")
   add_library(CeresMinimizer SHARED ceres/CeresMinimizer.cc G__CeresMinimizer.cxx)
   target_link_libraries(CeresMinimizer PUBLIC ${ROOT_LIBRARIES} Ceres::ceres)
   target_include_directories(CeresMinimizer PUBLIC ${Ceres_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+  # Ensure the ROOT dictionary and rootmap are placed next to the plugin library
+  add_custom_command(TARGET CeresMinimizer POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer_rdict.pcm
+            $<TARGET_FILE_DIR:CeresMinimizer>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer.rootmap
+            $<TARGET_FILE_DIR:CeresMinimizer>)
   install(TARGETS CeresMinimizer LIBRARY DESTINATION lib)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libCeresMinimizer_rdict.pcm DESTINATION lib)
+  install(FILES $<TARGET_FILE_DIR:CeresMinimizer>/libCeresMinimizer_rdict.pcm
+                $<TARGET_FILE_DIR:CeresMinimizer>/libCeresMinimizer.rootmap
+          DESTINATION lib)
 else()
   message(STATUS "Ceres not found - CeresMinimizer plugin will be unavailable")
 endif()

--- a/ceres/CeresMinimizer_LinkDef.h
+++ b/ceres/CeresMinimizer_LinkDef.h
@@ -3,5 +3,4 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ class CeresMinimizer+;
-#pragma link C++ function createCeresMinimizer;
 #endif

--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -9,7 +9,11 @@ using RootIMultiGradFunction = ROOT::Math::IGradientFunctionMultiDim;
 #include "Math/IFunction.h"
 using RootIMultiGradFunction = ROOT::Math::IMultiGradFunction;
 #endif
+#if __has_include(<ceres/ceres.h>)
 #include <ceres/ceres.h>
+#else
+#error "Ceres headers not found. Set CERES_PREFIX to the Ceres installation or install Ceres."
+#endif
 #include <string>
 #include <string_view>
 #include <vector>
@@ -73,6 +77,12 @@ public:
   unsigned int NDim() const override { return nDim_; }
   unsigned int NFree() const override { return nFree_; }
 
+  // ROOT's Minimizer did not historically expose a virtual Status()
+  // method, so we avoid using the 'override' keyword here to keep
+  // compatibility across ROOT versions while still allowing callers to
+  // query the minimizer termination code when available.
+  int Status() const { return status_; }
+
   bool ProvidesError() const override { return true; }
   const double *Errors() const override { return errors_.empty() ? nullptr : errors_.data(); }
   double CovMatrix(unsigned int i, unsigned int j) const override {
@@ -115,6 +125,8 @@ private:
 
   double numDiffStep_;
   bool forceNumeric_;
+
+  int status_;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- avoid vanishing gradients when the NLL is offset to zero by giving the Ceres cost a small epsilon and scaling residuals as sqrt(2*(f+eps))
- report the Ceres termination code through ROOT's `Status()` method for downstream error handling without relying on the `override` keyword
- generate and stage the Ceres minimizer's PCM and rootmap alongside the shared library for runtime loading
- allow custom `CERES_PREFIX` hints in Makefile/CMake and emit a clear error when Ceres headers are missing

## Testing
- `make CERES=1 build/obj/CeresMinimizer.o` *(fails: root-config: No such file or directory)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ROOT'; ModuleNotFoundError: No module named 'six`)*

------
https://chatgpt.com/codex/tasks/task_e_68b500c051108329ac9a58b4af7d2cfd