### PR TITLE
Add configurable Ceres covariance options

### DIFF
--- a/ceres/CeresMinimizer.cc
+++ b/ceres/CeresMinimizer.cc
@@ -355,6 +355,17 @@ bool CeresMinimizer::Minimize() {
   bool covOK = false;
   if (bestProblem && bestSummary.IsSolutionUsable()) {
     ceres::Covariance::Options covOpts;
+    std::string covAlgo = std::getenv("CERES_COVARIANCE_ALGO") ? std::getenv("CERES_COVARIANCE_ALGO") : std::string("dense_svd");
+    if (covAlgo == "dense_svd")
+      covOpts.algorithm_type = ceres::DENSE_SVD;
+    else if (covAlgo == "sparse_qr")
+      covOpts.algorithm_type = ceres::SPARSE_QR;
+    else if (covAlgo == "dense_qr")
+      covOpts.algorithm_type = ceres::DENSE_QR;
+    else if (covAlgo == "sparse_normal_cholesky")
+      covOpts.algorithm_type = ceres::SPARSE_NORMAL_CHOLESKY;
+    if (const char *env = std::getenv("CERES_COVARIANCE_MIN_RCN"))
+      covOpts.min_reciprocal_condition_number = std::atof(env);
     ceres::Covariance covariance(covOpts);
     std::vector<std::pair<const double *, const double *>> blocks;
     blocks.emplace_back(x_.data(), x_.data());

--- a/docs/part3/runningthetool.md
+++ b/docs/part3/runningthetool.md
@@ -137,6 +137,8 @@ Additional flags allow direct control over the Ceres solver:
 * `--cminCeresJitterDist arg`: choose jitter distribution `uniform` or `gaussian`.
 * `--cminCeresBoundRelax arg`: relax parameter bounds by this amount.
 * `--cminCeresAutoThreads`: use hardware concurrency if thread count not specified.
+* `--cminCeresCovAlgo arg`: covariance computation algorithm (`dense_svd`, `sparse_qr`, …).
+* `--cminCeresCovMinRCN arg`: minimum reciprocal condition number used in covariance computation (default `1e-12`).
 
 Ceres will fall back to numerical derivatives if an analytic gradient is not provided by the likelihood function.
 

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -931,7 +931,13 @@ void CascadeMinimizer::initOptions() {
       boost::program_options::value<double>()->default_value(0.0),
       "Symmetric relaxation applied to parameter bounds")("cminCeresAutoThreads",
                                                           boost::program_options::bool_switch()->default_value(false),
-                                                          "Set Ceres threads to hardware concurrency when unspecified")
+                                                          "Set Ceres threads to hardware concurrency when unspecified")(
+      "cminCeresCovAlgo",
+      boost::program_options::value<std::string>()->default_value("dense_svd"),
+      "Algorithm for Ceres covariance computation (dense_svd, sparse_qr, ...)")(
+      "cminCeresCovMinRCN",
+      boost::program_options::value<double>()->default_value(1e-12),
+      "Minimum reciprocal condition number for Ceres covariance")
       //("cminNuisancePruning", boost::program_options::value<double>(&nuisancePruningThreshold_)->default_value(nuisancePruningThreshold_), "if non-zero, discard constrained nuisances whose effect on the NLL when changing by 0.2*range is less than the absolute value of the threshold; if threshold is negative, repeat afterwards the fit with these floating")
 
       //("cminDefaultIntegratorEpsAbs", boost::program_options::value<double>(), "RooAbsReal::defaultIntegratorConfig()->setEpsAbs(x)")
@@ -1273,6 +1279,27 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
   if (vm["cminCeresAutoThreads"].as<bool>()) {
     setenv("CERES_AUTO_THREADS", "1", 1);
   }
+  if (vm.count("cminCeresCovAlgo")) {
+    std::string v = vm["cminCeresCovAlgo"].as<std::string>();
+    static const std::set<std::string> allowed{"dense_svd", "sparse_qr", "dense_qr", "sparse_normal_cholesky"};
+    if (!allowed.count(v)) {
+      CombineLogger::instance().log("CascadeMinimizer.cc",
+                                    __LINE__,
+                                    Form("Unknown Ceres covariance algorithm %s, defaulting to dense_svd", v.c_str()),
+                                    __func__);
+      v = "dense_svd";
+    }
+    setenv("CERES_COVARIANCE_ALGO", v.c_str(), 1);
+  }
+  if (vm.count("cminCeresCovMinRCN")) {
+    double val = vm["cminCeresCovMinRCN"].as<double>();
+    if (val <= 0) {
+      val = 1e-12;
+      CombineLogger::instance().log(
+          "CascadeMinimizer.cc", __LINE__, "cminCeresCovMinRCN must be >0, using 1e-12", __func__);
+    }
+    setenv("CERES_COVARIANCE_MIN_RCN", std::to_string(val).c_str(), 1);
+  }
 
   // after applying all options, print a summary of the minimizer configuration
   if (defaultMinimizerType_ == "Ceres") {
@@ -1350,6 +1377,8 @@ void CascadeMinimizer::printCeresConfig(int verbose) {
   logEnv("CERES_FORCE_NUMERIC", "--cminCeresUseNumericGradient");
   logEnv("CERES_PROGRESS", "--cminCeresProgress");
   logEnv("CERES_AUTO_THREADS", "--cminCeresAutoThreads");
+  logEnv("CERES_COVARIANCE_ALGO", "--cminCeresCovAlgo");
+  logEnv("CERES_COVARIANCE_MIN_RCN", "--cminCeresCovMinRCN");
 }
 
 //void CascadeMinimizer::setDefaultIntegrator(RooCategory &cat, const std::string & val) {

--- a/test/unit/testCeresCovarianceRankDef.cxx
+++ b/test/unit/testCeresCovarianceRankDef.cxx
@@ -1,0 +1,36 @@
+#include <RooRealVar.h>
+#include <RooDataSet.h>
+#include <RooGaussian.h>
+#include <RooFormulaVar.h>
+#include <RooMinimizer.h>
+#include <RooFitResult.h>
+#include <RooRandom.h>
+#include <TMatrixDSym.h>
+#include <Math/MinimizerOptions.h>
+#include <memory>
+#include <cstdlib>
+#include <cmath>
+
+int main() {
+    setenv("CERES_COVARIANCE_ALGO", "dense_svd", 1);
+    RooRealVar x("x","x",-10,10);
+    RooRealVar m1("m1","m1",0,-10,10);
+    RooRealVar m2("m2","m2",0,-10,10);
+    RooFormulaVar mean("mean","@0+@1",RooArgList(m1,m2));
+    RooRealVar sigma("sigma","sigma",1);
+    sigma.setConstant(true);
+    RooGaussian gauss("gauss","gauss",x,mean,sigma);
+    RooDataSet data("data","data",x);
+    RooRandom::randomGenerator()->SetSeed(1234);
+    for (int i=0; i<100; ++i) { x.setVal(RooRandom::randomGenerator()->Gaus()); data.add(x); }
+    std::unique_ptr<RooAbsReal> nll(gauss.createNLL(data));
+    RooMinimizer minim(*nll);
+    minim.setMinimizerType("Ceres");
+    minim.migrad();
+    minim.hesse();
+    std::unique_ptr<RooFitResult> res(minim.save());
+    const TMatrixDSym &cov = res->covarianceMatrix();
+    if (cov.GetNrows() != 2) return 1;
+    if (!std::isfinite(cov(0,0)) || !std::isfinite(cov(1,1))) return 1;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow setting Ceres covariance algorithm and minimum reciprocal condition number via `--cminCeresCovAlgo` and `--cminCeresCovMinRCN`
- propagate covariance options through environment variables and apply in `CeresMinimizer`
- document new Ceres covariance flags and add regression test for rank-deficient models

## Testing
- `cd test/unit && make testCeresCovarianceRankDef.exe` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b50f9666c483299187b39908e20bde