### PR TITLE
Fix Ceres NLL clamping and enforce bounds for fixed variables

### DIFF
--- a/interface/CeresMinimizer.h
+++ b/interface/CeresMinimizer.h
@@ -101,6 +101,7 @@ private:
     CostFunction(const RootIMultiGradFunction *f);
     bool Evaluate(double const *const *parameters, double *residuals, double **jacobians) const override;
     const RootIMultiGradFunction *func;
+    mutable double offset_;
   };
 
   const ROOT::Math::IMultiGenFunction *func_;


### PR DESCRIPTION
## Summary
- avoid clamping negative NLL contributions in Ceres cost evaluation
- ensure fixed variables honour bounds in Ceres minimizer
- dynamically shift NLL so square-root residuals remain valid without epsilon

## Testing
- `make -j4` *(fails: root-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b51b96fcdc8329b7afcb065528217e