### PR TITLE
Handle dynamic offset in Ceres minimizer

### DIFF
--- a/ceres/CeresMinimizer.cc
+++ b/ceres/CeresMinimizer.cc
@@ -111,12 +111,20 @@ bool CeresMinimizer::CostFunction::Evaluate(double const *const *parameters,
   // combine often offsets the objective so that fval can be zero or even
   // negative at the starting point. Shift the objective dynamically to keep
   // the argument of the square root positive while leaving the gradient of the
-  // original function unchanged.
-  if (fval + offset_ <= 0)
-    offset_ = -fval + 1.0;
+  // original function unchanged. The offset grows monotonically, but the
+  // residual is evaluated with the previous offset so the true NLL differences
+  // are preserved.
   const double shiftedF = fval + offset_;
   const double sqrtF = std::sqrt(2.0 * shiftedF);
   residuals[0] = sqrtF;
+  if (std::getenv("CERES_DEBUG_EVAL")) {
+    CombineLogger::instance().log(
+        "CeresMinimizer.cc", __LINE__,
+        Form("grad eval f=%.6f offset=%.6f shiftedF=%.6f", fval, offset_,
+             shiftedF),
+        __func__);
+  }
+  offset_ = std::max(offset_, -fval + 1.0);
   if (jacobians && jacobians[0]) {
     std::vector<double> grad(func->NDim());
     func->Gradient(x, grad.data());
@@ -136,11 +144,17 @@ struct NumericCostFunction : public ceres::CostFunction {
   bool Evaluate(double const *const *parameters, double *residuals, double **jacobians) const override {
     const double *x = parameters[0];
     const double fval = (*func)(x);
-    if (fval + offset_ <= 0)
-      offset_ = -fval + 1.0;
     const double shiftedF = fval + offset_;
     const double sqrtF = std::sqrt(2.0 * shiftedF);
     residuals[0] = sqrtF;
+    if (std::getenv("CERES_DEBUG_EVAL")) {
+      CombineLogger::instance().log(
+          "CeresMinimizer.cc", __LINE__,
+          Form("numeric eval f=%.6f offset=%.6f shiftedF=%.6f", fval, offset_,
+               shiftedF),
+          __func__);
+    }
+    offset_ = std::max(offset_, -fval + 1.0);
     if (jacobians && jacobians[0]) {
       std::vector<double> xtmp(func->NDim());
       std::copy(x, x + func->NDim(), xtmp.begin());
@@ -240,6 +254,7 @@ bool CeresMinimizer::Minimize() {
   double bestFval = std::numeric_limits<double>::infinity();
   ceres::Solver::Summary bestSummary;
   std::unique_ptr<ceres::Problem> bestProblem;
+  double bestOffset = 0.0;
 
   std::mt19937 rng(seed);
   std::uniform_real_distribution<double> dist(-1.0, 1.0);
@@ -329,15 +344,27 @@ bool CeresMinimizer::Minimize() {
         summary = altSummary;
       }
     }
-    double fval = (*func_)(x_.data());
+    double offset = 0.0;
+    if (auto c = dynamic_cast<CeresMinimizer::CostFunction *>(cost))
+      offset = c->offset_;
+    else if (auto n = dynamic_cast<NumericCostFunction *>(cost))
+      offset = n->offset_;
+    double fval = summary.final_cost - offset;
     if (verbose)
       CombineLogger::instance().log(
-          "CeresMinimizer.cc", __LINE__, Form("multi-start %u fval %.6f", it, fval), __func__);
+          "CeresMinimizer.cc", __LINE__,
+          Form("multi-start %u fval %.6f raw %.6f offset %.6f", it, fval,
+               summary.final_cost, offset),
+          __func__);
+    if (!summary.IsSolutionUsable() && verbose)
+      CombineLogger::instance().log("CeresMinimizer.cc", __LINE__,
+                                   "solution unusable", __func__);
     if (summary.IsSolutionUsable() && fval < bestFval) {
       bestFval = fval;
       xbest = x_;
       bestSummary = summary;
       bestProblem = std::move(problem);
+      bestOffset = offset;
     }
   }
   if (maxTime > 0.0) {
@@ -350,6 +377,12 @@ bool CeresMinimizer::Minimize() {
 
   x_ = xbest;
   nCalls_ = bestSummary.num_successful_steps + bestSummary.num_unsuccessful_steps;
+  bestSummary.initial_cost -= bestOffset;
+  bestSummary.final_cost -= bestOffset;
+  if (verbose)
+    CombineLogger::instance().log("CeresMinimizer.cc", __LINE__,
+                                   Form("best offset %.6f", bestOffset),
+                                   __func__);
   fMinVal_ = bestFval;
   grad_.assign(nDim_, 0.0);
   hess_.assign(nDim_ * nDim_, 0.0);


### PR DESCRIPTION
## Summary
- Evaluate residuals with the previous dynamic shift and grow the offset afterwards
- Add debug logging for cost evaluations and report offsets in solver summaries

## Testing
- `make -j2` *(fails: root-config not found, genreflex not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51f3524f08329997d5ed5c2cf0fb2