### PR TITLE
Add experimental MoreFit backend scaffolding and build toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(HiggsAnalysisCombinedLimit VERSION 0.0.1)
 option( MODIFY_ROOTMAP "Modify generated Rootmap to take out classes already bundled in StatAnalysis" FALSE )
 option( INSTALL_PYTHON "Install the Python library and scripts" TRUE )
 option( USE_VDT "Use VDT (fast and vectorisable mathematical functions)" TRUE )
+option( USE_MOREFIT "Build with experimental MoreFit backend" OFF )
 
 # Can build with CMake after e.g. setting up StatAnalysis release like this:
 # export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
@@ -13,7 +14,7 @@ option( USE_VDT "Use VDT (fast and vectorisable mathematical functions)" TRUE )
 # cmake path/to/source # change this path to where-ever you cloned Combine repo to
 # make -j4
 
-find_package(ROOT REQUIRED COMPONENTS MathMore RooFitCore RooFit RooStats HistFactory)
+find_package(ROOT REQUIRED COMPONENTS MathMore RooFitCore RooFit RooStats HistFactory Minuit2)
 find_package(Eigen3 REQUIRED)
 find_package(Vdt)
 find_package(LCG QUIET) # only used for FindBoost in StatAnalysis
@@ -50,6 +51,29 @@ else()
   target_link_libraries (${LIBNAME} VDT::VDT)
 endif()
 
+if(USE_MOREFIT)
+  find_package(OpenCL QUIET)
+  find_package(LLVM CONFIG QUIET)
+  find_package(Clang CONFIG QUIET)
+  if(OpenCL_FOUND AND LLVM_FOUND AND Clang_FOUND)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/morefit/minuit2)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+                    ${ROOT_INCLUDE_DIRS}
+                    ${CMAKE_CURRENT_BINARY_DIR}/morefit/minuit2/inc)
+    add_library(morefit_interface INTERFACE)
+    target_include_directories(morefit_interface INTERFACE
+      ${CMAKE_CURRENT_SOURCE_DIR}/morefit/include
+      ${CMAKE_CURRENT_BINARY_DIR}/morefit)
+    target_link_libraries(morefit_interface INTERFACE
+      OpenCL::OpenCL ROOT::Minuit2 clang-cpp LLVM)
+    target_link_libraries(${LIBNAME} PRIVATE morefit_interface)
+    target_compile_definitions(${LIBNAME} PRIVATE USE_MOREFIT)
+    add_executable(combineMoreFitDemo bin/combineMoreFitDemo.cc)
+    target_link_libraries(combineMoreFitDemo PUBLIC ${LIBNAME})
+  else()
+    message(WARNING "MoreFit dependencies not found. Building without MoreFit support.")
+  endif()
+endif()
 add_executable(combine bin/combine.cpp)
 target_link_libraries(combine PUBLIC ${LIBNAME})
 

--- a/README.md
+++ b/README.md
@@ -10,4 +10,20 @@ The source code of this documentation can be found in the `docs/` folder in this
 
 ### Publication 
 
-The `Combine` tool publication can be found [here](https://arxiv.org/abs/2404.06614). Please consider citing this reference if you use the `Combine` tool. 
+The `Combine` tool publication can be found [here](https://arxiv.org/abs/2404.06614). Please consider citing this reference if you use the `Combine` tool.
+
+### Experimental MoreFit backend
+
+An optional integration of the [MoreFit](https://github.com/cms-analysis/MoreFit) likelihood engine is provided for
+development and benchmarking.  It reuses the Minuit2 library already bundled with ROOT to avoid duplication of
+dependencies and is disabled by default.  To build with the backend enabled run:
+
+```
+cmake -DUSE_MOREFIT=ON ..
+```
+
+The build also produces a small `combineMoreFitDemo` executable that prints the
+result of a dummy evaluation to confirm the backend was compiled in.
+
+At runtime the backend can be selected with `--backend=morefit`.  The feature is experimental and should not alter
+existing RooFit behaviour when left at the default.

--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -27,6 +27,7 @@
 #include "../interface/ProfilingTools.h"
 #include "../interface/GenerateOnly.h"
 #include "../interface/CombineLogger.h"
+#include "../src/BackendConfig.h"
 #include <map>
 
 using namespace std;
@@ -46,6 +47,7 @@ int main(int argc, char **argv) {
   int runToys;
   int    seed;
   string toysFile;
+  string backendStr;
 
   vector<string> librariesToLoad;
   vector<string> runtimeDefines;
@@ -86,6 +88,7 @@ int main(int argc, char **argv) {
     ("method,M",      po::value<string>(&whichMethod)->default_value("AsymptoticLimits"), methodsDesc.c_str())
     ("verbose,v",  po::value<int>(&verbose)->default_value(0), "Verbosity level (-1 = very quiet; 0 = quiet, 1 = verbose, 2+ = debug)")
     ("help,h", "Produce help message")
+    ("backend", po::value<string>(&backendStr)->default_value("roofit"), "Likelihood backend (roofit or morefit)")
     ;
   combiner.statOptions().add_options()
     ("toys,t", po::value<int>(&runToys)->default_value(0), "Number of Toy MC extractions")
@@ -168,6 +171,7 @@ int main(int argc, char **argv) {
   try{
     po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     po::notify(vm);
+    BackendConfig::instance().setBackendFromString(backendStr);
   } catch(std::exception &ex) {
     cerr << "Invalid options: " << ex.what() << endl;
     cout << "Invalid options: " << ex.what() << endl;

--- a/bin/combineMoreFitDemo.cc
+++ b/bin/combineMoreFitDemo.cc
@@ -1,0 +1,9 @@
+#include "../src/MoreFitBackend.h"
+#include <iostream>
+
+int main(int argc, char** argv) {
+    (void)argc; (void)argv;
+    MoreFitBackend backend;
+    std::cout << "MoreFit demo evaluate = " << backend.evaluate() << std::endl;
+    return 0;
+}

--- a/docs/morefit-architecture-notes.md
+++ b/docs/morefit-architecture-notes.md
@@ -1,0 +1,30 @@
+# MoreFit Architecture Notes
+
+## Combine likelihood flow
+- Datacards are parsed into a `RooWorkspace` which contains `RooAbsPdf` models and `RooAbsData` datasets.
+- The `combine` CLI drives algorithms derived from `LimitAlgo`.
+- `FitterAlgoBase::run` is the common entry point for fits; it creates the NLL via `combineCreateNLL` which wraps `RooAbsPdf::createNLL` and honours the selected evaluation backend.
+- The returned `RooAbsReal` is minimised by `CascadeMinimizer`, a convenience wrapper around `RooMinimizer`/Minuit2.  The FCN, gradient and Hessian therefore come from RooFit.
+- Typical call chain for a fit diagnostic is
+  `datacard → RooWorkspace → FitterAlgoBase::run → combineCreateNLL → RooMinimizer → Minuit2`.
+
+## MoreFit building blocks
+- Public headers live in `morefit/include/`:
+  - `dimension.hh`/`dimensionvector.hh` describe observable axes.
+  - `parametervector.hh`/`parameter` encode fit parameters.
+  - `pdf.hh` and `physicspdfs.hh` provide PDF classes (Gaussian, CrystalBall, etc.) and `SumPDF` combiners.
+  - `graph.hh` represents symbolic computation graphs that can be JIT‑compiled.
+  - `compute.hh`, `compute_opencl.hh`, `compute_llvm.hh` implement evaluation backends; options select OpenCL GPUs or LLVM JIT on CPU.
+  - `fitter.hh` contains the Minuit2 adapter and `fitter_options` (minimiser type, analytic gradient/Hessian toggles, optimisation of parameter/event terms).
+  - `generator.hh` and `random.hh` expose accelerated toy generation with host or device random numbers.
+
+MoreFit is largely header-only but ships a private copy of **Minuit2** under `morefit/minuit2/`.  For Combine we intend to reuse the Minuit2 library already provided by ROOT and treat the bundled copy as unused.
+
+Key external dependencies are `Eigen3`, `OpenCL`, and `Clang/LLVM` for the JIT backends.
+
+## Backend features
+- Evaluation builds a graph once and executes it on the chosen backend.  Parameter‑only and event‑only subgraphs can be cached to minimise recomputation when data or parameters change.
+- Analytic gradients and Hessians are available via `fitter_options` (`analytic_gradient`, `analytic_hessian`); numerical derivatives are used if disabled.
+- Generator can run on OpenCL devices or threaded LLVM code with configurable seeds and work‑item scheduling.
+
+These notes capture the entry points and main classes needed for integrating MoreFit as an alternative likelihood backend in Combine.

--- a/docs/morefit-dependencies.md
+++ b/docs/morefit-dependencies.md
@@ -1,0 +1,20 @@
+# MoreFit/Combine Dependency Overview
+
+## Combine
+- ROOT (RooFit, RooStats, Minuit2, MathMore)
+- Eigen3
+- Boost (program_options, filesystem)
+- Optional VDT
+
+## MoreFit
+- Eigen3
+- Clang/LLVM (JIT)
+- OpenCL
+- Private copy of Minuit2 under `morefit/minuit2/`
+- Optional ROOT for benchmarks
+
+## Overlap and plan
+- Shared: Minuit2, Eigen3.
+- Combine already links ROOT's Minuit2; the MoreFit build will reuse this library and omit the bundled copy to avoid duplication.
+- Eigen3 is resolved once and shared.
+- Clang/LLVM and OpenCL remain optional extras for MoreFit.

--- a/docs/morefit-integration-plan.md
+++ b/docs/morefit-integration-plan.md
@@ -1,0 +1,53 @@
+# MoreFit Integration Plan
+
+## Architecture
+- Introduce an abstract `ILikelihoodBackend` with hooks:
+  - `prepareForDataset(const RooAbsData*)`
+  - `prepareForParams(const RooArgList*)`
+  - `double evaluate()`
+  - `bool gradient(std::vector<double>&)`
+  - `bool hessian(std::vector<double>&)`
+- Implementations:
+  - **RooFitBackend** – wraps current RooFit objects and preserves existing behaviour (default).
+  - **MoreFitBackend** – builds MoreFit computation graphs, selects OpenCL or LLVM backends and exposes analytic derivatives when available.
+
+## Dependency considerations
+- Combine already depends on ROOT, which provides RooFit and the **Minuit2** minimiser.
+- MoreFit requires Minuit2, Eigen3, Clang/LLVM and OpenCL; it also ships a private Minuit2 copy.
+- To avoid duplication, the build will reuse ROOT’s Minuit2 and Eigen3 and ignore the copy under `morefit/minuit2`.
+
+## CMake
+- New option `USE_MOREFIT` (OFF by default).
+- When ON, locate `LLVM/Clang`, `OpenCL`, and reuse existing `Eigen3`/`ROOT::Minuit2`.
+- If dependencies are satisfied, expose `morefit/include` and link against `ROOT::Minuit2`, `clang-cpp`, `LLVM` and `OpenCL`; otherwise emit a warning and disable the backend.
+- Add compile definition `USE_MOREFIT` to conditionally build MoreFit code paths.
+
+## Model translation
+- A `RooToMoreFitConverter` will map a subset of RooFit classes to MoreFit:
+  - Observables `RooRealVar` → `morefit::dimension`.
+  - Parameters `RooRealVar` → `morefit::parameter`.
+  - Supported PDFs: `Gaussian`, `CrystalBall`, `Exponential`, `Polynomial`, `SumPDF`, and log‑normal constraints.
+- Unsupported nodes trigger a warning and fall back to `RooFitBackend`.
+
+## Minuit2 usage
+- Combine continues to drive `CascadeMinimizer`/Minuit2.
+- `RooFitBackend` passes the usual FCN without derivatives.
+- `MoreFitBackend` provides analytic gradient/Hessian to Minuit2 via `fitter_options`; if unavailable the interface returns `false` and the minimiser falls back to numerical derivatives.
+
+## Toy generation
+- Expose MoreFit’s `generator` alongside RooFit’s generator.
+- Options allow choosing host/device randomisation, OpenCL platform/device, threads and vector width for LLVM.
+- Generated datasets are written out in standard ROOT format.
+
+## Runtime selection
+- Add command line option `--backend {roofit,morefit}`.
+- MoreFit-specific flags: `--mf-backend={opencl,llvm}`, `--mf-opencl-platform`, `--mf-opencl-device`, `--mf-threads`, `--mf-vector-width`, `--mf-analytic-derivatives=on|off`, `--mf-event-precompute=auto|off`.
+
+## Validation & benchmarks
+- Parity tests: compare parameter values, errors and FCN between RooFit and MoreFit backends for canonical Combine examples. Require FCN agreement within `1e-6` relative or justify deviations.
+- Micro-benchmarks: measure fit time, likelihood scans and toy generation on CPU/GPU; report speed-ups and resource usage.
+
+## Rollout
+- Feature flag hidden behind `USE_MOREFIT` and the `--backend` runtime option.
+- CI matrix builds with and without MoreFit; failures in MoreFit build are initially non-blocking.
+- Documentation and examples accompany each milestone.

--- a/docs/morefit-milestone-0.md
+++ b/docs/morefit-milestone-0.md
@@ -1,0 +1,10 @@
+# Milestone 0 — Skeleton + Build Toggle
+
+- [ ] **CMake:** add `USE_MOREFIT` option; when ON, include `morefit/` headers and reuse ROOT’s `Minuit2` instead of the bundled copy.
+  *Acceptance:* `cmake .. -DUSE_MOREFIT=ON` configures; OFF builds as today; ON builds without modifying any Combine code paths.
+- [ ] **Interfaces:** add `interface/ILikelihoodBackend.h` (pure virtual API with `evaluate`, `gradient`, `hessian`, `prepareForDataset`, `prepareForParams`).
+- [ ] **RooFit backend:** add `src/RooFitBackend.{h,cc}` implementing `ILikelihoodBackend` using current RooFit NLL evaluation.  This remains the default.
+- [ ] **CLI scaffolding:** introduce `src/BackendConfig.{h,cc}` and parse `--backend` in `combine` to store the chosen backend.
+- [ ] **Documentation:** update `README.md` describing the `USE_MOREFIT` build toggle and experimental intent.
+
+Completion of these tasks establishes the skeleton for later MoreFit integration without affecting existing behaviour.

--- a/interface/ILikelihoodBackend.h
+++ b/interface/ILikelihoodBackend.h
@@ -1,0 +1,24 @@
+#ifndef HIGGSANALYSIS_COMBINEDLIMIT_ILIKELIHOODBACKEND_H
+#define HIGGSANALYSIS_COMBINEDLIMIT_ILIKELIHOODBACKEND_H
+
+#include <vector>
+
+class RooAbsData;
+class RooArgList;
+
+class ILikelihoodBackend {
+public:
+    virtual ~ILikelihoodBackend() = default;
+    /// Called when a new dataset is bound to the likelihood
+    virtual void prepareForDataset(const RooAbsData* data) { (void)data; }
+    /// Called when parameter pointers change
+    virtual void prepareForParams(const RooArgList* params) { (void)params; }
+    /// Evaluate the negative log-likelihood
+    virtual double evaluate() = 0;
+    /// Fill gradient vector; return false if not available
+    virtual bool gradient(std::vector<double>& grad) { (void)grad; return false; }
+    /// Fill Hessian matrix (row-major); return false if not available
+    virtual bool hessian(std::vector<double>& hess) { (void)hess; return false; }
+};
+
+#endif

--- a/src/BackendConfig.cc
+++ b/src/BackendConfig.cc
@@ -1,0 +1,19 @@
+#include "BackendConfig.h"
+
+BackendConfig& BackendConfig::instance() {
+    static BackendConfig cfg;
+    return cfg;
+}
+
+void BackendConfig::setBackend(Backend b) { backend_ = b; }
+
+void BackendConfig::setBackendFromString(const std::string& name) {
+    if (name == "morefit") backend_ = Backend::MoreFit;
+    else backend_ = Backend::RooFit;
+}
+
+BackendConfig::Backend BackendConfig::backend() const { return backend_; }
+
+std::string BackendConfig::backendName() const {
+    return backend_ == Backend::MoreFit ? "morefit" : "roofit";
+}

--- a/src/BackendConfig.h
+++ b/src/BackendConfig.h
@@ -1,0 +1,21 @@
+#ifndef HIGGSANALYSIS_COMBINEDLIMIT_BACKENDCONFIG_H
+#define HIGGSANALYSIS_COMBINEDLIMIT_BACKENDCONFIG_H
+
+#include <string>
+
+class BackendConfig {
+public:
+    enum class Backend { RooFit, MoreFit };
+
+    static BackendConfig& instance();
+
+    void setBackend(Backend b);
+    void setBackendFromString(const std::string& name);
+    Backend backend() const;
+    std::string backendName() const;
+
+private:
+    Backend backend_{Backend::RooFit};
+};
+
+#endif

--- a/src/MoreFitBackend.cc
+++ b/src/MoreFitBackend.cc
@@ -1,0 +1,31 @@
+#include "MoreFitBackend.h"
+
+MoreFitBackend::MoreFitBackend() = default;
+MoreFitBackend::~MoreFitBackend() = default;
+
+double MoreFitBackend::evaluate() {
+#ifdef USE_MOREFIT
+    // real implementation will call morefit graph execution
+    return 0.0;
+#else
+    return 0.0;
+#endif
+}
+
+bool MoreFitBackend::gradient(std::vector<double>& grad) {
+    (void)grad;
+#ifdef USE_MOREFIT
+    return false;
+#else
+    return false;
+#endif
+}
+
+bool MoreFitBackend::hessian(std::vector<double>& hess) {
+    (void)hess;
+#ifdef USE_MOREFIT
+    return false;
+#else
+    return false;
+#endif
+}

--- a/src/MoreFitBackend.h
+++ b/src/MoreFitBackend.h
@@ -1,0 +1,25 @@
+#ifndef HIGGSANALYSIS_COMBINEDLIMIT_MOREFITBACKEND_H
+#define HIGGSANALYSIS_COMBINEDLIMIT_MOREFITBACKEND_H
+
+#include "HiggsAnalysis/CombinedLimit/interface/ILikelihoodBackend.h"
+
+#ifdef USE_MOREFIT
+#include "morefit/include/morefit.hh"
+#endif
+
+class MoreFitBackend : public ILikelihoodBackend {
+public:
+    MoreFitBackend();
+    ~MoreFitBackend() override;
+
+    double evaluate() override;
+    bool gradient(std::vector<double>& grad) override;
+    bool hessian(std::vector<double>& hess) override;
+
+private:
+#ifdef USE_MOREFIT
+    // placeholders for MoreFit objects
+#endif
+};
+
+#endif

--- a/src/RooFitBackend.cc
+++ b/src/RooFitBackend.cc
@@ -1,0 +1,19 @@
+#include "RooFitBackend.h"
+#include "RooAbsReal.h"
+
+RooFitBackend::RooFitBackend(std::unique_ptr<RooAbsReal> nll) : nll_(std::move(nll)) {}
+RooFitBackend::~RooFitBackend() = default;
+
+double RooFitBackend::evaluate() {
+    return nll_ ? nll_->getVal() : 0.0;
+}
+
+bool RooFitBackend::gradient(std::vector<double>& grad) {
+    (void)grad;
+    return false;
+}
+
+bool RooFitBackend::hessian(std::vector<double>& hess) {
+    (void)hess;
+    return false;
+}

--- a/src/RooFitBackend.h
+++ b/src/RooFitBackend.h
@@ -1,0 +1,22 @@
+#ifndef HIGGSANALYSIS_COMBINEDLIMIT_ROOFITBACKEND_H
+#define HIGGSANALYSIS_COMBINEDLIMIT_ROOFITBACKEND_H
+
+#include "HiggsAnalysis/CombinedLimit/interface/ILikelihoodBackend.h"
+#include <memory>
+
+class RooAbsReal;
+
+class RooFitBackend : public ILikelihoodBackend {
+public:
+    explicit RooFitBackend(std::unique_ptr<RooAbsReal> nll);
+    ~RooFitBackend() override;
+
+    double evaluate() override;
+    bool gradient(std::vector<double>& grad) override;
+    bool hessian(std::vector<double>& hess) override;
+
+private:
+    std::unique_ptr<RooAbsReal> nll_;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- Document MoreFit architecture, integration plan, and initial milestone
- Add `USE_MOREFIT` CMake option linking MoreFit when dependencies are available
- Introduce `ILikelihoodBackend` with RooFit and MoreFit stub backends and runtime selection
- Provide demo executable `combineMoreFitDemo` and README notes

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'ROOT', 'six')*

------
https://chatgpt.com/codex/tasks/task_e_68b63fbe2d8c8329927abf97498bc0f6