### PR TITLE
Detect Conda prefix for dependencies in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ option( USE_MOREFIT "Build with experimental MoreFit backend" OFF )
 # cmake path/to/source # change this path to where-ever you cloned Combine repo to
 # make -j4
 
+if(DEFINED ENV{CONDA_PREFIX} AND NOT CMAKE_PREFIX_PATH)
+  list(APPEND CMAKE_PREFIX_PATH $ENV{CONDA_PREFIX})
+  message(STATUS "Detected Conda prefix: $ENV{CONDA_PREFIX}")
+endif()
+
 find_package(ROOT REQUIRED COMPONENTS MathMore RooFitCore RooFit RooStats HistFactory Minuit2)
 find_package(Eigen3 REQUIRED)
 find_package(Vdt)


### PR DESCRIPTION
## Summary
- Allow CMake to automatically use `$CONDA_PREFIX` when `CMAKE_PREFIX_PATH` is unset
- Emit a status message when the Conda prefix is detected

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'ROOT')*


------
https://chatgpt.com/codex/tasks/task_e_68b64a43e6d083298bd53d1aaa699d0f