### PR TITLE
Unset LD_LIBRARY_PATH during builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,20 @@ file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} src/*.c*)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/HiggsAnalysis)
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/HiggsAnalysis/CombinedLimit" )
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+# Avoid Conda's libreadline being preloaded by clearing LD_LIBRARY_PATH
+if(DEFINED ENV{LD_LIBRARY_PATH})
+  set(_COMBINE_SAVED_LD_LIBRARY_PATH "$ENV{LD_LIBRARY_PATH}")
+  unset(ENV{LD_LIBRARY_PATH})
+endif()
 
 ROOT_GENERATE_DICTIONARY(G__${LIBNAME} HiggsAnalysis/CombinedLimit/src/classes.h LINKDEF src/classes_def.xml
         MODULE ${LIBNAME}
         OPTIONS ${ROOTCLING_OPTIONS})
+
+if(DEFINED _COMBINE_SAVED_LD_LIBRARY_PATH)
+  set(ENV{LD_LIBRARY_PATH} "${_COMBINE_SAVED_LD_LIBRARY_PATH}")
+  unset(_COMBINE_SAVED_LD_LIBRARY_PATH)
+endif()
 add_library(${LIBNAME} SHARED ${SOURCES} G__${LIBNAME}.cxx)
 set_target_properties(${LIBNAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")
 target_link_libraries(${LIBNAME} PUBLIC Eigen3::Eigen ${ROOT_LIBRARIES} ${Boost_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ dependencies and is disabled by default. To build with the backend enabled:
 
 ```
 mkdir build && cd build
-cmake .. -DUSE_MOREFIT=ON
-make -j$(nproc)
+cmake -E env --unset=LD_LIBRARY_PATH cmake .. -DUSE_MOREFIT=ON
+cmake -E env --unset=LD_LIBRARY_PATH make -j$(nproc)
 ```
 
 When a Conda environment is active, CMake automatically consumes
@@ -32,6 +32,10 @@ libraries from the environment.  It also preloads Conda’s `libstdc++` and
 `-DCMAKE_PREFIX_PATH` explicitly to override or extend the search path. The
 build also produces a small `combineMoreFitDemo` executable that prints the
 result of a dummy evaluation to confirm the backend was compiled in.
+
+Using `cmake -E env --unset=LD_LIBRARY_PATH` ensures `/bin/sh` does not
+preload Conda's `libreadline`, preventing `rl_print_keybinding` errors during
+dictionary generation.
 
 At runtime the backend can be selected with `--backend=morefit`. The feature is
 experimental and should not alter existing RooFit behaviour when left at the


### PR DESCRIPTION
## Summary
- document how to call CMake and make via `cmake -E env --unset=LD_LIBRARY_PATH` to avoid Conda's `libreadline`
- temporarily clear `LD_LIBRARY_PATH` when generating ROOT dictionaries

## Testing
- `cmake -E env --unset=LD_LIBRARY_PATH cmake -S . -B build` *(fails: Could not find package ROOT)*
- `cmake -E env --unset=LD_LIBRARY_PATH make -C build` *(fails: No targets and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b658773ac48329b870c7972e760cef