### PR TITLE
Force include cassert for MoreFit backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,11 @@ if(USE_MOREFIT)
       OpenCL::OpenCL ROOT::Minuit2 clang-cpp LLVM)
     target_link_libraries(${LIBNAME} PRIVATE morefit_interface)
     target_compile_definitions(${LIBNAME} PRIVATE USE_MOREFIT)
+    set(MOREFIT_TUS ${CMAKE_CURRENT_SOURCE_DIR}/src/MoreFitBackend.cc)
+    target_compile_options(${LIBNAME} PRIVATE
+      $<$<COMPILE_LANGUAGE:CXX>:-include;cassert>)
+    set_source_files_properties(${MOREFIT_TUS}
+      PROPERTIES COMPILE_OPTIONS "-UNDEBUG")
     add_executable(combineMoreFitDemo bin/combineMoreFitDemo.cc)
     target_link_libraries(combineMoreFitDemo PUBLIC ${LIBNAME})
   else()


### PR DESCRIPTION
## Summary
- force-include `<cassert>` in MoreFit builds
- keep assertions enabled for `MoreFitBackend.cc`

## Testing
- `cmake -S . -B build -DUSE_MOREFIT=ON` *(fails: Could not find a package configuration file provided by "ROOT" )*


------
https://chatgpt.com/codex/tasks/task_e_68b65b6a97d48329b7a846e16ecb0a3e