### PR TITLE
Force include cassert for MoreFit backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,8 @@ if(USE_MOREFIT)
     target_link_libraries(${LIBNAME} PRIVATE morefit_interface)
     target_compile_definitions(${LIBNAME} PRIVATE USE_MOREFIT)
     set(MOREFIT_TUS ${CMAKE_CURRENT_SOURCE_DIR}/src/MoreFitBackend.cc)
-    target_compile_options(${LIBNAME} PRIVATE
-      $<$<COMPILE_LANGUAGE:CXX>:-include;cassert>)
     set_source_files_properties(${MOREFIT_TUS}
-      PROPERTIES COMPILE_OPTIONS "-UNDEBUG")
+      PROPERTIES COMPILE_OPTIONS "-include;cassert;-UNDEBUG")
     add_executable(combineMoreFitDemo bin/combineMoreFitDemo.cc)
     target_link_libraries(combineMoreFitDemo PUBLIC ${LIBNAME})
   else()


### PR DESCRIPTION
## Summary
- Force include `<cassert>` and enable assertions for MoreFit backend source files

## Testing
- `cmake .. -DUSE_MOREFIT=ON` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68b65d59fef8832985de3f65eca9331d