### PR TITLE
Handle Clang 16 diagnostics API change in MoreFit compiler

### DIFF
--- a/morefit/include/llvm_compiler.hh
+++ b/morefit/include/llvm_compiler.hh
@@ -13,6 +13,7 @@
 
 #include <llvm/IR/Module.h>
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/Support/VirtualFileSystem.h>
 #include <llvm/TargetParser/Host.h>
 
 #include "compute.hh"
@@ -83,7 +84,12 @@ namespace cc {
       assert(ok);
 
       //Setup custom diagnostic printer.
+#if CLANG_VERSION_MAJOR >= 16
+      CC.createDiagnostics(*llvm::vfs::getRealFileSystem(),
+                          DC.get(), false /* own DiagnosticConsumer */);
+#else
       CC.createDiagnostics(DC.get(), false /* own DiagnosticConsumer */);
+#endif
 
       //Configure remapping from pseudo file name to in-memory code buffer
       //PreprocessorOptions take ownership of MemoryBuffer.


### PR DESCRIPTION
## Summary
- Include `VirtualFileSystem.h` to access Clang's real filesystem
- Pass a `llvm::vfs::FileSystem` to `CompilerInstance::createDiagnostics` for Clang 16+

## Testing
- `g++ -std=c++17 -DUSE_MOREFIT -I . -I morefit/include -I interface -I src -I build_tmp -c src/MoreFitBackend.cc -o /tmp/MoreFitBackend.o` *(fails: clang/Basic/DiagnosticOptions.h: No such file or directory)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b66050980c8329a20d2967e629dba1